### PR TITLE
[core] Repeatable form input elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ $ ponzu --dev --fork=github.com/nilslice/ponzu new /path/to/new/project
 
 
 ### Logo
-The Go gopher was designed by Renee Frech. (http://reneefrench.blogspot.com)
+The Go gopher was designed by Renee French. (http://reneefrench.blogspot.com)
 The design is licensed under the Creative Commons 3.0 Attributions license.
 Read this article for more details: http://blog.golang.org/gopher
 

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -325,7 +325,7 @@ func Checkbox(fieldName string, p interface{}, attrs, options map[string]string)
 			}
 		}
 
-		// create a *element manually using the maodified tagNameFromStructFieldMulti
+		// create a *element manually using the modified tagNameFromStructFieldMulti
 		// func since this is for a multi-value name
 		input := &element{
 			TagName: "input",

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -15,7 +15,7 @@ import (
 // 	}
 //
 // 	func (p *Person) MarshalEditor() ([]byte, error) {
-// 		view, err := Form(p,
+// 		view, err := editor.Form(p,
 // 			editor.Field{
 // 				View: editor.Input("Name", p, map[string]string{
 // 					"label":       "Name",

--- a/management/editor/repeaters.go
+++ b/management/editor/repeaters.go
@@ -272,6 +272,7 @@ func RepeatController(fieldName string, p interface{}, inputSelector, cloneSelec
 							if ($elem.val() === '') {
 								$elem.attr('name', '');
 							} else {
+								$elem.attr('name', name);
 								preset = true;
 							}						
 						}

--- a/management/editor/repeaters.go
+++ b/management/editor/repeaters.go
@@ -269,7 +269,7 @@ func RepeatController(fieldName string, p interface{}, inputSelector, cloneSelec
 						// if the elem is not ` + inputSelector + ` and has no value 
 						// set the name to an empty string
 						if (!$elem.is('` + inputSelector + `')) {
-							if ($elem.val() === '') {
+							if ($elem.val() === '' || $elem.is('.file-path')) {
 								$elem.attr('name', '');
 							} else {
 								$elem.attr('name', name);
@@ -378,7 +378,7 @@ func RepeatController(fieldName string, p interface{}, inputSelector, cloneSelec
                 }
             }
 
-            applyRepeatControllers();
+			resetFieldNames();
         });
 
     </script>

--- a/management/editor/repeaters.go
+++ b/management/editor/repeaters.go
@@ -1,0 +1,204 @@
+package editor
+
+import (
+	"bytes"
+	"strings"
+)
+
+// RepeatSelect returns the []byte of a <select> HTML element plus internal <options> with a label.
+// IMPORTANT:
+// The `fieldName` argument will cause a panic if it is not exactly the string
+// form of the struct field that this editor input is representing
+func RepeatSelect(fieldName string, p interface{}, attrs, options map[string]string) []byte {
+	// options are the value attr and the display value, i.e.
+	// <option value="{map key}">{map value}</option>
+	scope := tagNameFromStructField(fieldName, p)
+	html := &bytes.Buffer{}
+	html.WriteString(`<span class="__ponzu-repeat ` + scope + `">`)
+
+	// find the field values in p to determine if an option is pre-selected
+	fieldVals := valueFromStructField(fieldName, p)
+	vals := strings.Split(fieldVals, "__ponzu")
+
+	attrs["class"] = "browser-default"
+
+	// loop through vals and create selects and options for each, adding to html
+	if len(vals) > 0 {
+		for i, val := range vals {
+			sel := &element{
+				TagName: "select",
+				Attrs:   attrs,
+				Name:    tagNameFromStructFieldMulti(fieldName, i, p),
+				viewBuf: &bytes.Buffer{},
+			}
+
+			// only add the label to the first select in repeated list
+			if i == 0 {
+				sel.label = attrs["label"]
+			}
+
+			// create options for select element
+			var opts []*element
+
+			// provide a call to action for the select element
+			cta := &element{
+				TagName: "option",
+				Attrs:   map[string]string{"disabled": "true", "selected": "true"},
+				data:    "Select an option...",
+				viewBuf: &bytes.Buffer{},
+			}
+
+			// provide a selection reset (will store empty string in db)
+			reset := &element{
+				TagName: "option",
+				Attrs:   map[string]string{"value": ""},
+				data:    "None",
+				viewBuf: &bytes.Buffer{},
+			}
+
+			opts = append(opts, cta, reset)
+
+			for k, v := range options {
+				optAttrs := map[string]string{"value": k}
+				if k == val {
+					optAttrs["selected"] = "true"
+				}
+				opt := &element{
+					TagName: "option",
+					Attrs:   optAttrs,
+					data:    v,
+					viewBuf: &bytes.Buffer{},
+				}
+
+				opts = append(opts, opt)
+			}
+
+			html.Write(domElementWithChildrenSelect(sel, opts))
+		}
+	}
+
+	html.WriteString(`</span>`)
+	return append(html.Bytes(), RepeatController(fieldName, p, "select")...)
+}
+
+// RepeatController generates the javascript to control any repeatable form
+// element in an editor based on its type, field name and HTML tag name
+func RepeatController(fieldName string, p interface{}, htmlTagName string) []byte {
+	scope := tagNameFromStructField(fieldName, p)
+	script := `
+    <script>
+        $(function() {
+            // define the scope of the repeater
+            var scope = $('.__ponzu-repeat.` + scope + `');
+
+            var getChildren = function() {
+                return scope.find('` + htmlTagName + `')
+            }
+
+            var resetFieldNames = function() {
+                // loop through children, set its name to the fieldName.i where
+                // i is the current index number of children array
+                var children = getChildren();
+                for (var i = 0; i < children.length; i++) {
+                    var el = children[i];
+                    $(el).attr('name', '` + scope + `.'+String(i));
+                    
+                    // reset controllers
+                    $(el).find('.controls').remove();
+                }
+
+                applyRepeatControllers();
+            }
+
+            var addRepeater = function(e) {
+                e.preventDefault();
+                
+                // find and clone the repeatable input-like element
+                var controls = $(e.target).parent();
+                var clone = controls.parent().clone();
+
+                // if repeat has label, remove it
+                clone.find('label').remove();
+                
+                // remove the pre-filled value from clone
+                clone.find('` + htmlTagName + `').val("");
+
+                // remove controls if already present
+                clone.find('.controls').remove();
+
+                // add clone to scope and reset field name attributes
+                scope.append(clone);
+
+                resetFieldNames();
+            }
+
+            var delRepeater = function(e) {
+                e.preventDefault();
+
+                // do nothing if the input is the only child
+                var children = getChildren();
+                if (children.length === 1) {
+                    return;
+                }
+
+                var del = e.target;
+                
+                // pass label onto next input-like element if del 0 index
+                var wrapper = $(del).parent().parent();
+                if (wrapper.find('` + htmlTagName + `').attr('name') === '` + scope + `.0') {
+                    wrapper.next().append(wrapper.find('label'))
+                }
+                
+                // find the outermost element which is the input-like element
+                // within the scope that contains the repeater control (-) and
+                // delete it
+                $(del).parent().parent().remove();
+
+                resetFieldNames();
+            }
+
+            var createControls = function() {
+                // create + / - controls for each input-like child element of scope
+                var add = $('<button>+</button>');
+                add.addClass('repeater-add');
+                add.addClass('btn-flat waves-effect waves-green');
+
+                var del = $('<button>-</button>');
+                del.addClass('repeater-del');
+                del.addClass('btn-flat waves-effect waves-red');                
+
+                var controls = $('<span></span>');
+                controls.addClass('controls');
+                controls.addClass('right');
+
+                // bind listeners to child's controls
+                add.on('click', addRepeater);
+                del.on('click', delRepeater);
+
+                controls.append(add);
+                controls.append(del);
+
+                return controls;
+            }
+
+            var applyRepeatControllers = function() {
+                // add controls to each child
+                var children = getChildren()
+                for (var i = 0; i < children.length; i++) {
+                    var el = children[i];
+                    
+                    $(el).parent().find('.controls').remove();
+                    
+                    var controls = createControls();                                        
+                    $(el).parent().append(controls);
+                }
+            }
+
+            applyRepeatControllers();
+        });
+
+    </script>
+    `
+
+	return []byte(script)
+}

--- a/management/editor/repeaters.go
+++ b/management/editor/repeaters.go
@@ -13,16 +13,16 @@ import (
 // The `fieldName` argument will cause a panic if it is not exactly the string
 // form of the struct field that this editor input is representing
 // 	type Person struct {
-// 		Name string `json:"name"`
+// 		Names []string `json:"names"`
 // 	}
 //
 // 	func (p *Person) MarshalEditor() ([]byte, error) {
 // 		view, err := editor.Form(p,
 // 			editor.Field{
-// 				View: editor.InputRepeater("Name", p, map[string]string{
-// 					"label":       "Name",
+// 				View: editor.InputRepeater("Names", p, map[string]string{
+// 					"label":       "Names",
 // 					"type":        "text",
-// 					"placeholder": "Enter the Name here",
+// 					"placeholder": "Enter a Name here",
 // 				}),
 // 			}
 // 		)

--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -136,7 +136,7 @@ func Manage(e editor.Editable, typeName string) ([]byte, error) {
 		ID:     i.ItemID(),
 		UUID:   i.UniqueID(),
 		Kind:   typeName,
-		Slug:   s.ItemSlug(), // TODO: just added this and its implementation -- need to rebuild & test
+		Slug:   s.ItemSlug(),
 		Editor: template.HTML(v),
 	}
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -1403,10 +1403,11 @@ func editHandler(res http.ResponseWriter, req *http.Request) {
 
 				if req.PostForm.Get(key) == "" {
 					req.PostForm.Set(key, v[0])
-					discardKeys = append(discardKeys, k)
 				} else {
 					req.PostForm.Add(key, v[0])
 				}
+
+				discardKeys = append(discardKeys, k)
 			}
 		}
 

--- a/system/admin/static/dashboard/css/admin.css
+++ b/system/admin/static/dashboard/css/admin.css
@@ -222,3 +222,7 @@ li:hover .quick-delete-post, li:hover .delete-user {
     text-align: right;
     padding: 10px 0 !important;
 }
+
+select {
+    border: 1px solid #e2e2e2;
+}

--- a/system/admin/static/dashboard/css/admin.css
+++ b/system/admin/static/dashboard/css/admin.css
@@ -185,6 +185,11 @@ li:hover .quick-delete-post, li:hover .delete-user {
     padding: 20px;
 }
 
+.controls button {
+    padding: 0px 10px 5px 10px;
+    position: relative;
+    top: -10px;
+}
 
 /* OVERRIDE Bootstrap + Materialize conflicts */
 .iso-texteditor.input-field label {

--- a/system/api/external.go
+++ b/system/api/external.go
@@ -85,10 +85,11 @@ func externalContentHandler(res http.ResponseWriter, req *http.Request) {
 
 			if req.PostForm.Get(key) == "" {
 				req.PostForm.Set(key, v[0])
-				discardKeys = append(discardKeys, k)
 			} else {
 				req.PostForm.Add(key, v[0])
 			}
+
+			discardKeys = append(discardKeys, k)
 		}
 	}
 

--- a/system/db/config.go
+++ b/system/db/config.go
@@ -34,10 +34,11 @@ func SetConfig(data url.Values) error {
 
 				if data.Get(key) == "" {
 					data.Set(key, v[0])
-					discardKeys = append(discardKeys, k)
 				} else {
 					data.Add(key, v[0])
 				}
+
+				discardKeys = append(discardKeys, k)
 			}
 		}
 


### PR DESCRIPTION
This PR introduces a new form editor input feature, "Repeaters". From time to time, it's not uncommon that a CMS user wants to add an arbitrary number of inputs for any single field. For example, a music playlist: each playlist has a name, and some varying number of songs associated. With Ponzu's new Repeaters, you can opt to make a Form editor which allows the user to add or remove any number of inputs within a field. 

For any type, such as:
```go
type Playlist struct {
        Songs []string `json:"songs"`
}
```
a corresponding MarshalEditor method would look like (take note of the InputRepeater):

```go
func (p *Playlist) MarshalEditor() ([]byte, error) {
	view, err := editor.Form(p,
		editor.Field{
			View: editor.InputRepeater("Songs", p, map[string]string{
				"label":       "Songs",
				"type":        "text",
				"placeholder": "Enter the Song here",
			}),
		},
	)

// ... 
``` 
Doing so will provide + / - controls in the input UI:
![ponzu repeaters](https://cloud.githubusercontent.com/assets/7517515/21448843/e2b65eac-c89b-11e6-98e0-08edb5bbcfea.png)

Currently there are Repeaters for Input, Select and File named `InputRepeater`, `SelectRepeater` and `FileRepeater`, respectively. 