### PR TITLE
[core] Adding toggle for CORS, GZIP in admin/cms configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,22 +80,17 @@ Errors will be reported, but successful commands return nothing.
 
 ### generate, gen, g
 
-Generate a content type file with boilerplate code to implement
-the editor.Editable interface. Must be given one (1) parameter of
-the name of the type for the new content. The fields following a 
-type determine the field names and types of the content struct to 
-be generated. These must be in the following format:
-fieldName:"T"
+Generate boilerplate code for various Ponzu components, such as `content`.
 
 Example:
 ```bash
-                   struct fields and built-in types...
-                   |
-                   v    
-$ ponzu gen review title:"string" body:"string" rating:"int" tags:"[]string"
-            ^
-            |
-            struct type
+            generator      struct fields and built-in types...
+             |              |
+             v              v    
+$ ponzu gen content review title:"string" body:"string" rating:"int" tags:"[]string"
+                     ^
+                     |
+                    struct type
 ```
 
 The command above will generate the file `content/review.go` with boilerplate

--- a/cmd/ponzu/main.go
+++ b/cmd/ponzu/main.go
@@ -110,6 +110,7 @@ func main() {
 		}
 
 	case "run":
+		fmt.Println("Running..")
 		var addTLS string
 		if https {
 			addTLS = "--https"
@@ -127,6 +128,8 @@ func main() {
 		} else {
 			services = "admin,api"
 		}
+
+		fmt.Println("services:", services)
 
 		serve := exec.Command("./ponzu-server",
 			fmt.Sprintf("--port=%d", port),

--- a/cmd/ponzu/main.go
+++ b/cmd/ponzu/main.go
@@ -193,7 +193,7 @@ func main() {
 			fmt.Println("Enabling HTTPS...")
 
 			go tls.Enable()
-			fmt.Printf("Server listening on :%s for HTTPS requests...\n", db.ConfigCache("https_port"))
+			fmt.Printf("Server listening on :%s for HTTPS requests...\n", db.ConfigCache("https_port").(string))
 		}
 
 		// save the https port the system is listening on so internal system can make

--- a/cmd/ponzu/main.go
+++ b/cmd/ponzu/main.go
@@ -80,7 +80,7 @@ func main() {
 
 	case "new":
 		if len(args) < 2 {
-			fmt.Println(usage)
+			fmt.Println(usageNew)
 			os.Exit(0)
 		}
 
@@ -91,15 +91,19 @@ func main() {
 		}
 
 	case "generate", "gen", "g":
-		if len(args) < 2 {
-			flag.PrintDefaults()
+		if len(args) < 3 {
+			fmt.Println(usageGenerate)
 			os.Exit(0)
 		}
 
-		err := generateContentType(args[1:])
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+		// check what we are asked to generate
+		switch args[2] {
+		case "content", "c":
+			err := generateContentType(args[2:])
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
 		}
 
 	case "build":

--- a/cmd/ponzu/main.go
+++ b/cmd/ponzu/main.go
@@ -153,21 +153,30 @@ func main() {
 			os.Exit(1)
 		}
 
+		fmt.Println("serve command executed.")
+
 	case "serve", "s":
 		db.Init()
 		defer db.Close()
+		fmt.Println("called db.Init()")
 
 		analytics.Init()
 		defer analytics.Close()
+		fmt.Println("called analytics.Init()")
 
 		if len(args) > 1 {
 			services := strings.Split(args[1], ",")
+			fmt.Println("configured to start services:", services)
 
 			for i := range services {
 				if services[i] == "api" {
 					api.Run()
+					fmt.Println("called api.Run()")
+
 				} else if services[i] == "admin" {
 					admin.Run()
+					fmt.Println("called admin.Run()")
+
 				} else {
 					fmt.Println("To execute 'ponzu serve', you must specify which service to run.")
 					fmt.Println("$ ponzu --help")
@@ -179,8 +188,9 @@ func main() {
 		// save the https port the system is listening on
 		err := db.PutConfig("https_port", fmt.Sprintf("%d", httpsport))
 		if err != nil {
-			log.Fatalln("System failed to save config. Please try to run again.")
+			log.Fatalln("System failed to save config. Please try to run again.", err)
 		}
+		fmt.Println("called db.PutConfig('https_port')")
 
 		// cannot run production HTTPS and development HTTPS together
 		if devhttps {
@@ -203,10 +213,12 @@ func main() {
 		// HTTP api calls while in dev or production w/o adding more cli flags
 		err = db.PutConfig("http_port", fmt.Sprintf("%d", port))
 		if err != nil {
-			log.Fatalln("System failed to save config. Please try to run again.")
+			log.Fatalln("System failed to save config. Please try to run again.", err)
 		}
+		fmt.Println("called db.PutConfig('http_port')")
 
 		log.Fatalln(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))
+		fmt.Println("called http.ListenAndServe()")
 
 	case "":
 		fmt.Println(usage)

--- a/cmd/ponzu/main.go
+++ b/cmd/ponzu/main.go
@@ -99,6 +99,7 @@ func main() {
 		// check what we are asked to generate
 		switch args[2] {
 		case "content", "c":
+			fmt.Println(args, "|", args[2])
 			err := generateContentType(args[2:])
 			if err != nil {
 				fmt.Println(err)

--- a/cmd/ponzu/main.go
+++ b/cmd/ponzu/main.go
@@ -97,14 +97,16 @@ func main() {
 		}
 
 		// check what we are asked to generate
-		switch args[2] {
+		switch args[1] {
 		case "content", "c":
-			fmt.Println(args, "|", args[2])
 			err := generateContentType(args[2:])
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)
 			}
+		default:
+			msg := fmt.Sprintf("Generator '%s' is not implemented.", args[1])
+			fmt.Println(msg)
 		}
 
 	case "build":

--- a/cmd/ponzu/main.go
+++ b/cmd/ponzu/main.go
@@ -117,7 +117,6 @@ func main() {
 		}
 
 	case "run":
-		fmt.Println("Running..")
 		var addTLS string
 		if https {
 			addTLS = "--https"
@@ -135,8 +134,6 @@ func main() {
 		} else {
 			services = "admin,api"
 		}
-
-		fmt.Println("services:", services)
 
 		serve := exec.Command("./ponzu-server",
 			fmt.Sprintf("--port=%d", port),
@@ -160,29 +157,22 @@ func main() {
 			os.Exit(1)
 		}
 
-		fmt.Println("serve command executed.")
-
 	case "serve", "s":
 		db.Init()
 		defer db.Close()
-		fmt.Println("called db.Init()")
 
 		analytics.Init()
 		defer analytics.Close()
-		fmt.Println("called analytics.Init()")
 
 		if len(args) > 1 {
 			services := strings.Split(args[1], ",")
-			fmt.Println("configured to start services:", services)
 
 			for i := range services {
 				if services[i] == "api" {
 					api.Run()
-					fmt.Println("called api.Run()")
 
 				} else if services[i] == "admin" {
 					admin.Run()
-					fmt.Println("called admin.Run()")
 
 				} else {
 					fmt.Println("To execute 'ponzu serve', you must specify which service to run.")
@@ -197,7 +187,6 @@ func main() {
 		if err != nil {
 			log.Fatalln("System failed to save config. Please try to run again.", err)
 		}
-		fmt.Println("called db.PutConfig('https_port')")
 
 		// cannot run production HTTPS and development HTTPS together
 		if devhttps {
@@ -222,10 +211,10 @@ func main() {
 		if err != nil {
 			log.Fatalln("System failed to save config. Please try to run again.", err)
 		}
-		fmt.Println("called db.PutConfig('http_port')")
 
+		fmt.Printf("Server listening on :%d for HTTP requests...\n", port)
+		fmt.Println("\nvisit `/admin` to get started.")
 		log.Fatalln(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))
-		fmt.Println("called http.ListenAndServe()")
 
 	case "":
 		fmt.Println(usage)

--- a/cmd/ponzu/usage.go
+++ b/cmd/ponzu/usage.go
@@ -10,11 +10,10 @@ var year = fmt.Sprintf("%d", time.Now().Year())
 var usageHeader = `
 $ ponzu [flags] command <params>
 
-Ponzu is a powerful and efficient open-source "Content-as-a-Service" system 
-framework and CMS. It provides automatic, free, and secure HTTP/2 over TLS 
-(certificates obtained via Let's Encrypt - https://letsencrypt.org), a useful 
-CMS and  scaffolding to generate content editors, and a fast HTTP API on which 
-to build modern applications.
+Ponzu is a powerful and efficient open-source HTTP server framework and CMS. It 
+provides automatic, free, and secure HTTP/2 over TLS (certificates obtained via 
+[Let's Encrypt](https://letsencrypt.org)), a useful CMS and scaffolding to 
+generate content editors, and a fast HTTP API on which to build modern applications.
 
 Ponzu is released under the BSD-3-Clause license (see LICENSE).
 (c) ` + year + ` Boss Sauce Creative, LLC

--- a/cmd/ponzu/usage.go
+++ b/cmd/ponzu/usage.go
@@ -54,17 +54,12 @@ new <directory>:
 `
 
 var usageGenerate = `
-generate, gen, g <type (,...fields)>:
+generate, gen, g <generator type (,...fields)>:
 
-	Generate a content type file with boilerplate code to implement
-	the editor.Editable interface. Must be given one (1) parameter of
-	the name of the type for the new content. The fields following a 
-	type determine the field names and types of the content struct to 
-	be generated. These must be in the following format:
-	fieldName:"T"
+	Generate boilerplate code for various Ponzu components, such as 'content'.
 
 	Example:
-	$ ponzu gen review title:"string" body:"string" rating:"int" tags:"[]string"
+	$ ponzu gen content review title:"string" body:"string" rating:"int" tags:"[]string"
 
 	The command above will generate a file 'content/review.go' with boilerplate
 	methods, as well as struct definition, and cooresponding field tags like:

--- a/system/addon/api.go
+++ b/system/addon/api.go
@@ -18,8 +18,8 @@ type QueryOptions db.QueryOptions
 
 // ContentAll retrives all items from the HTTP API within the provided namespace
 func ContentAll(namespace string) []byte {
-	host := db.ConfigCache("domain")
-	port := db.ConfigCache("http_port")
+	host := db.ConfigCache("domain").(string)
+	port := db.ConfigCache("http_port").(string)
 	endpoint := "http://%s:%s/api/contents?type=%s&count=-1"
 	URL := fmt.Sprintf(endpoint, host, port, namespace)
 
@@ -35,8 +35,8 @@ func ContentAll(namespace string) []byte {
 // Query retrieves a set of content from the HTTP API  based on options
 // and returns the total number of content in the namespace and the content
 func Query(namespace string, opts QueryOptions) []byte {
-	host := db.ConfigCache("domain")
-	port := db.ConfigCache("http_port")
+	host := db.ConfigCache("domain").(string)
+	port := db.ConfigCache("http_port").(string)
 	endpoint := "http://%s:%s/api/contents?type=%s&count=%d&offset=%d&order=%s"
 	URL := fmt.Sprintf(endpoint, host, port, namespace, opts.Count, opts.Offset, opts.Order)
 

--- a/system/admin/config/config.go
+++ b/system/admin/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	ClientSecret    string   `json:"client_secret"`
 	Etag            string   `json:"etag"`
 	DisableCORS     bool     `json:"cors_disabled"`
+	DisableGZIP     bool     `json:"gzip_disabled"`
 	CacheInvalidate []string `json:"cache"`
 }
 
@@ -78,6 +79,13 @@ func (c *Config) MarshalEditor() ([]byte, error) {
 		editor.Field{
 			View: editor.Checkbox("DisableCORS", c, map[string]string{
 				"label": "Disable CORS (so only " + c.Domain + " can fetch your data)",
+			}, map[string]string{
+				"true": "Disable",
+			}),
+		},
+		editor.Field{
+			View: editor.Checkbox("DisableGZIP", c, map[string]string{
+				"label": "Disable GZIP (will increase server speed, but also bandwidth)",
 			}, map[string]string{
 				"true": "Disable",
 			}),

--- a/system/admin/config/config.go
+++ b/system/admin/config/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	AdminEmail      string   `json:"admin_email"`
 	ClientSecret    string   `json:"client_secret"`
 	Etag            string   `json:"etag"`
-	DisableCORS     []string `json:"cors_disabled"`
+	DisableCORS     []bool   `json:"cors_disabled"`
 	CacheInvalidate []string `json:"cache"`
 }
 

--- a/system/admin/config/config.go
+++ b/system/admin/config/config.go
@@ -79,7 +79,7 @@ func (c *Config) MarshalEditor() ([]byte, error) {
 			View: editor.Checkbox("DisableCORS", c, map[string]string{
 				"label": "Disable CORS (so only " + c.Domain + " can fetch your data)",
 			}, map[string]string{
-				"on": "Disable",
+				"true": "Disable",
 			}),
 		},
 		editor.Field{

--- a/system/admin/config/config.go
+++ b/system/admin/config/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	AdminEmail      string   `json:"admin_email"`
 	ClientSecret    string   `json:"client_secret"`
 	Etag            string   `json:"etag"`
-	DisableCORS     []bool   `json:"cors_disabled"`
+	DisableCORS     bool     `json:"cors_disabled"`
 	CacheInvalidate []string `json:"cache"`
 }
 

--- a/system/admin/config/config.go
+++ b/system/admin/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	AdminEmail      string   `json:"admin_email"`
 	ClientSecret    string   `json:"client_secret"`
 	Etag            string   `json:"etag"`
+	DisableCORS     []string `json:"cors_disabled"`
 	CacheInvalidate []string `json:"cache"`
 }
 
@@ -49,7 +50,7 @@ func (c *Config) MarshalEditor() ([]byte, error) {
 		},
 		editor.Field{
 			View: editor.Input("AdminEmail", c, map[string]string{
-				"label": "Adminstrator Email (will be notified of internal system information)",
+				"label": "Adminstrator Email (notified of internal system information)",
 			}),
 		},
 		editor.Field{
@@ -65,13 +66,20 @@ func (c *Config) MarshalEditor() ([]byte, error) {
 		},
 		editor.Field{
 			View: editor.Input("Etag", c, map[string]string{
-				"label":    "Etag Header (used for static asset cache)",
+				"label":    "Etag Header (used to cache resources)",
 				"disabled": "true",
 			}),
 		},
 		editor.Field{
 			View: editor.Input("Etag", c, map[string]string{
 				"type": "hidden",
+			}),
+		},
+		editor.Field{
+			View: editor.Checkbox("DisableCORS", c, map[string]string{
+				"label": "Disable CORS (so only " + c.Domain + " can fetch your data)",
+			}, map[string]string{
+				"true": "Disable",
 			}),
 		},
 		editor.Field{

--- a/system/admin/config/config.go
+++ b/system/admin/config/config.go
@@ -79,7 +79,7 @@ func (c *Config) MarshalEditor() ([]byte, error) {
 			View: editor.Checkbox("DisableCORS", c, map[string]string{
 				"label": "Disable CORS (so only " + c.Domain + " can fetch your data)",
 			}, map[string]string{
-				"true": "Disable",
+				"on": "Disable",
 			}),
 		},
 		editor.Field{

--- a/system/admin/config/config.go
+++ b/system/admin/config/config.go
@@ -80,14 +80,14 @@ func (c *Config) MarshalEditor() ([]byte, error) {
 			View: editor.Checkbox("DisableCORS", c, map[string]string{
 				"label": "Disable CORS (so only " + c.Domain + " can fetch your data)",
 			}, map[string]string{
-				"true": "Disable",
+				"true": "Disable CORS",
 			}),
 		},
 		editor.Field{
 			View: editor.Checkbox("DisableGZIP", c, map[string]string{
 				"label": "Disable GZIP (will increase server speed, but also bandwidth)",
 			}, map[string]string{
-				"true": "Disable",
+				"true": "Disable GZIP",
 			}),
 		},
 		editor.Field{

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -1533,7 +1533,7 @@ func editHandler(res http.ResponseWriter, req *http.Request) {
 
 		// create a timestamp if one was not set
 		if ts == "" {
-			ts := fmt.Sprintf("%d", time.Now().Unix()*1000)
+			ts := fmt.Sprintf("%d", int64(time.Nanosecond)*time.Now().UnixNano()/int64(time.Millisecond))
 			req.PostForm.Set("timestamp", ts)
 		}
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -1533,7 +1533,7 @@ func editHandler(res http.ResponseWriter, req *http.Request) {
 
 		// create a timestamp if one was not set
 		if ts == "" {
-			ts := fmt.Sprintf("%d", int64(time.Nanosecond)*time.Now().UnixNano()/int64(time.Millisecond))
+			ts = fmt.Sprintf("%d", int64(time.Nanosecond)*time.Now().UnixNano()/int64(time.Millisecond))
 			req.PostForm.Set("timestamp", ts)
 		}
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -92,7 +92,7 @@ func initHandler(res http.ResponseWriter, req *http.Request) {
 		}
 
 		// set HTTP port which should be previously added to config cache
-		port := db.ConfigCache("http_port")
+		port := db.ConfigCache("http_port").(string)
 		req.Form.Set("http_port", port)
 
 		// set initial user email as admin_email and make config

--- a/system/admin/server.go
+++ b/system/admin/server.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -53,6 +52,4 @@ func Run() {
 	// through the editor will not load within the admin system.
 	uploadsDir := filepath.Join(pwd, "uploads")
 	http.Handle("/api/uploads/", api.Record(api.CORS(db.CacheControl(http.StripPrefix("/api/uploads/", http.FileServer(restrict(http.Dir(uploadsDir))))))))
-
-	fmt.Println("Admin routes registered.")
 }

--- a/system/admin/server.go
+++ b/system/admin/server.go
@@ -52,9 +52,7 @@ func Run() {
 	// even if the API server is not running. Otherwise, images/files uploaded
 	// through the editor will not load within the admin system.
 	uploadsDir := filepath.Join(pwd, "uploads")
-	http.Handle("/api/uploads/", api.Record(api.CORS(db.CacheControl(
-		http.StripPrefix("/api/uploads/", http.FileServer(
-			restrict(http.Dir(uploadsDir))))))))
+	http.Handle("/api/uploads/", api.Record(api.CORS(db.CacheControl(http.StripPrefix("/api/uploads/", http.FileServer(restrict(http.Dir(uploadsDir))))))))
 
 	fmt.Println("Admin routes registered.")
 }

--- a/system/admin/server.go
+++ b/system/admin/server.go
@@ -51,5 +51,7 @@ func Run() {
 	// even if the API server is not running. Otherwise, images/files uploaded
 	// through the editor will not load within the admin system.
 	uploadsDir := filepath.Join(pwd, "uploads")
-	http.Handle("/api/uploads/", api.Record(db.CacheControl(http.StripPrefix("/api/uploads/", http.FileServer(restrict(http.Dir(uploadsDir)))))))
+	http.Handle("/api/uploads/", api.Record(api.CORS(db.CacheControl(
+		http.StripPrefix("/api/uploads/", http.FileServer(
+			restrict(http.Dir(uploadsDir))))))))
 }

--- a/system/admin/server.go
+++ b/system/admin/server.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -54,4 +55,6 @@ func Run() {
 	http.Handle("/api/uploads/", api.Record(api.CORS(db.CacheControl(
 		http.StripPrefix("/api/uploads/", http.FileServer(
 			restrict(http.Dir(uploadsDir))))))))
+
+	fmt.Println("Admin routes registered.")
 }

--- a/system/admin/upload/upload.go
+++ b/system/admin/upload/upload.go
@@ -20,7 +20,7 @@ func StoreFiles(req *http.Request) (map[string]string, error) {
 	ts := req.FormValue("timestamp") // timestamp in milliseconds since unix epoch
 
 	if ts == "" {
-		ts = fmt.Sprintf("%d", time.Now().Unix()*1000) // Unix() returns seconds since unix epoch
+		ts = fmt.Sprintf("%d", int64(time.Nanosecond)*time.Now().UnixNano()/int64(time.Millisecond)) // Unix() returns seconds since unix epoch
 	}
 
 	req.Form.Set("timestamp", ts)

--- a/system/api/external.go
+++ b/system/api/external.go
@@ -61,7 +61,7 @@ func externalContentHandler(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	ts := fmt.Sprintf("%d", time.Now().Unix()*1000)
+	ts := fmt.Sprintf("%d", int64(time.Nanosecond)*time.Now().UnixNano()/int64(time.Millisecond))
 	req.PostForm.Set("timestamp", ts)
 	req.PostForm.Set("updated", ts)
 

--- a/system/api/handlers.go
+++ b/system/api/handlers.go
@@ -254,13 +254,12 @@ func sendPreflight(res http.ResponseWriter) {
 
 // CORS wraps a HandleFunc to respond to OPTIONS requests properly
 func CORS(next http.HandlerFunc) http.HandlerFunc {
-	if db.ConfigCache("cors_disabled").([]string)[0] == "true" {
-		return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-			res.WriteHeader(http.StatusForbidden)
-		})
-	}
-
 	return db.CacheControl(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if db.ConfigCache("cors_disabled").(bool) == true {
+			res.WriteHeader(http.StatusForbidden)
+			return
+		}
+
 		if req.Method == http.MethodOptions {
 			sendPreflight(res)
 			return

--- a/system/api/handlers.go
+++ b/system/api/handlers.go
@@ -254,6 +254,12 @@ func sendPreflight(res http.ResponseWriter) {
 
 // CORS wraps a HandleFunc to respond to OPTIONS requests properly
 func CORS(next http.HandlerFunc) http.HandlerFunc {
+	if db.ConfigCache("cors_disabled").([]string)[0] == "true" {
+		return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			res.WriteHeader(http.StatusForbidden)
+		})
+	}
+
 	return db.CacheControl(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		if req.Method == http.MethodOptions {
 			sendPreflight(res)

--- a/system/api/handlers.go
+++ b/system/api/handlers.go
@@ -231,7 +231,7 @@ func toJSON(data []string) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// sendData() should be used any time you want to communicate
+// sendData should be used any time you want to communicate
 // data back to a foreign client
 func sendData(res http.ResponseWriter, data []byte, code int) {
 	res, cors := responseWithCORS(res)

--- a/system/api/handlers.go
+++ b/system/api/handlers.go
@@ -323,6 +323,11 @@ func Record(next http.HandlerFunc) http.HandlerFunc {
 // Gzip wraps a HandlerFunc to compress responses when possible
 func Gzip(next http.HandlerFunc) http.HandlerFunc {
 	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if db.ConfigCache("gzip_disabled").(bool) == true {
+			next.ServeHTTP(res, req)
+			return
+		}
+
 		// check if req header content-encoding supports gzip
 		if strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") {
 			// gzip response data
@@ -330,7 +335,6 @@ func Gzip(next http.HandlerFunc) http.HandlerFunc {
 			gzres := gzipResponseWriter{res, gzip.NewWriter(res)}
 
 			next.ServeHTTP(gzres, req)
-
 			return
 		}
 

--- a/system/api/server.go
+++ b/system/api/server.go
@@ -4,11 +4,9 @@ import "net/http"
 
 // Run adds Handlers to default http listener for API
 func Run() {
-	http.HandleFunc("/api/types", Record(CORS(typesHandler)))
-
 	http.HandleFunc("/api/contents", Record(CORS(contentsHandler)))
 
 	http.HandleFunc("/api/content", Record(CORS(contentHandler)))
 
-	http.HandleFunc("/api/content/external", Record(CORS(externalContentHandler)))
+	http.HandleFunc("/api/content/external", Record(externalContentHandler))
 }

--- a/system/api/server.go
+++ b/system/api/server.go
@@ -1,9 +1,6 @@
 package api
 
-import (
-	"fmt"
-	"net/http"
-)
+import "net/http"
 
 // Run adds Handlers to default http listener for API
 func Run() {
@@ -14,6 +11,4 @@ func Run() {
 	http.HandleFunc("/api/content", Record(CORS(contentHandler)))
 
 	http.HandleFunc("/api/content/external", Record(CORS(externalContentHandler)))
-
-	fmt.Println("API routes registered.")
 }

--- a/system/api/server.go
+++ b/system/api/server.go
@@ -4,9 +4,9 @@ import "net/http"
 
 // Run adds Handlers to default http listener for API
 func Run() {
-	http.HandleFunc("/api/contents", Record(CORS(contentsHandler)))
+	http.HandleFunc("/api/contents", Record(CORS(Gzip(contentsHandler))))
 
-	http.HandleFunc("/api/content", Record(CORS(contentHandler)))
+	http.HandleFunc("/api/content", Record(CORS(Gzip(contentHandler))))
 
 	http.HandleFunc("/api/content/external", Record(externalContentHandler))
 }

--- a/system/api/server.go
+++ b/system/api/server.go
@@ -4,11 +4,11 @@ import "net/http"
 
 // Run adds Handlers to default http listener for API
 func Run() {
-	http.HandleFunc("/api/types", CORS(Record(typesHandler)))
+	http.HandleFunc("/api/types", Record(CORS(typesHandler)))
 
-	http.HandleFunc("/api/contents", CORS(Record(contentsHandler)))
+	http.HandleFunc("/api/contents", Record(CORS(contentsHandler)))
 
-	http.HandleFunc("/api/content", CORS(Record(contentHandler)))
+	http.HandleFunc("/api/content", Record(CORS(contentHandler)))
 
-	http.HandleFunc("/api/content/external", CORS(Record(externalContentHandler)))
+	http.HandleFunc("/api/content/external", Record(CORS(externalContentHandler)))
 }

--- a/system/api/server.go
+++ b/system/api/server.go
@@ -1,6 +1,9 @@
 package api
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+)
 
 // Run adds Handlers to default http listener for API
 func Run() {
@@ -11,4 +14,6 @@ func Run() {
 	http.HandleFunc("/api/content", Record(CORS(contentHandler)))
 
 	http.HandleFunc("/api/content/external", Record(CORS(externalContentHandler)))
+
+	fmt.Println("API routes registered.")
 }

--- a/system/db/addon.go
+++ b/system/db/addon.go
@@ -119,7 +119,7 @@ func DeleteAddon(key string) error {
 	err := store.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte("__addons"))
 		if b == nil {
-			bolt.ErrBucketNotFound
+			return bolt.ErrBucketNotFound
 		}
 
 		if err := b.Delete([]byte(key)); err != nil {

--- a/system/db/cache.go
+++ b/system/db/cache.go
@@ -11,7 +11,7 @@ import (
 // CacheControl sets the default cache policy on static asset responses
 func CacheControl(next http.Handler) http.HandlerFunc {
 	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		etag := ConfigCache("etag")
+		etag := ConfigCache("etag").(string)
 		policy := fmt.Sprintf("max-age=%d, public", 60*60*24*30)
 		res.Header().Add("ETag", etag)
 		res.Header().Add("Cache-Control", policy)

--- a/system/db/config.go
+++ b/system/db/config.go
@@ -134,6 +134,10 @@ func PutConfig(key string, value interface{}) error {
 		return err
 	}
 
+	if c == nil {
+		return nil
+	}
+
 	err = json.Unmarshal(c, &kv)
 	if err != nil {
 		return err

--- a/system/db/config.go
+++ b/system/db/config.go
@@ -180,6 +180,8 @@ func LoadCacheConfig() error {
 		return err
 	}
 
+	fmt.Println(string(c))
+
 	// convert json => map[string]interface{} => url.Values
 	var kv map[string]interface{}
 	err = json.Unmarshal(c, &kv)

--- a/system/db/config.go
+++ b/system/db/config.go
@@ -22,49 +22,53 @@ func init() {
 // SetConfig sets key:value pairs in the db for configuration settings
 func SetConfig(data url.Values) error {
 	var j []byte
-	err := store.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte("__config"))
 
-		// check for any multi-value fields (ex. checkbox fields)
-		// and correctly format for db storage. Essentially, we need
-		// fieldX.0: value1, fieldX.1: value2 => fieldX: []string{value1, value2}
-		var discardKeys []string
-		for k, v := range data {
-			if strings.Contains(k, ".") {
-				key := strings.Split(k, ".")[0]
+	// check for any multi-value fields (ex. checkbox fields)
+	// and correctly format for db storage. Essentially, we need
+	// fieldX.0: value1, fieldX.1: value2 => fieldX: []string{value1, value2}
+	var discardKeys []string
+	for k, v := range data {
+		if strings.Contains(k, ".") {
+			key := strings.Split(k, ".")[0]
 
-				if data.Get(key) == "" {
-					data.Set(key, v[0])
-				} else {
-					data.Add(key, v[0])
-				}
-
-				discardKeys = append(discardKeys, k)
+			if data.Get(key) == "" {
+				data.Set(key, v[0])
+			} else {
+				data.Add(key, v[0])
 			}
-		}
 
-		for _, discardKey := range discardKeys {
-			data.Del(discardKey)
+			discardKeys = append(discardKeys, k)
 		}
+	}
 
-		cfg := &config.Config{}
-		dec := schema.NewDecoder()
-		dec.SetAliasTag("json")     // allows simpler struct tagging when creating a content type
-		dec.IgnoreUnknownKeys(true) // will skip over form values submitted, but not in struct
-		err := dec.Decode(cfg, data)
-		if err != nil {
-			return err
-		}
+	for _, discardKey := range discardKeys {
+		data.Del(discardKey)
+	}
 
-		// check for "invalidate" value to reset the Etag
-		if len(cfg.CacheInvalidate) > 0 && cfg.CacheInvalidate[0] == "invalidate" {
-			cfg.Etag = NewEtag()
-			cfg.CacheInvalidate = []string{}
-		}
+	cfg := &config.Config{}
+	dec := schema.NewDecoder()
+	dec.SetAliasTag("json")     // allows simpler struct tagging when creating a content type
+	dec.IgnoreUnknownKeys(true) // will skip over form values submitted, but not in struct
+	err := dec.Decode(cfg, data)
+	if err != nil {
+		return err
+	}
 
-		j, err = json.Marshal(cfg)
-		if err != nil {
-			return err
+	// check for "invalidate" value to reset the Etag
+	if len(cfg.CacheInvalidate) > 0 && cfg.CacheInvalidate[0] == "invalidate" {
+		cfg.Etag = NewEtag()
+		cfg.CacheInvalidate = []string{}
+	}
+
+	j, err = json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+
+	err = store.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("__config"))
+		if b == nil {
+			return bolt.ErrBucketNotFound
 		}
 
 		err = b.Put([]byte("settings"), j)
@@ -117,7 +121,7 @@ func ConfigAll() ([]byte, error) {
 	err := store.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte("__config"))
 		if b == nil {
-			return fmt.Errorf("Error finding bucket: %s", "__config")
+			return bolt.ErrBucketNotFound
 		}
 		_, err := val.Write(b.Get([]byte("settings")))
 		if err != nil {

--- a/system/db/config.go
+++ b/system/db/config.go
@@ -135,7 +135,10 @@ func PutConfig(key string, value interface{}) error {
 	}
 
 	if c == nil {
-		return nil
+		c, err = emptyConfig()
+		if err != nil {
+			return err
+		}
 	}
 
 	err = json.Unmarshal(c, &kv)
@@ -185,8 +188,10 @@ func LoadCacheConfig() error {
 	}
 
 	if c == nil {
-		configCache = make(url.Values)
-		return nil
+		c, err = emptyConfig()
+		if err != nil {
+			return err
+		}
 	}
 
 	// convert json => map[string]interface{} => url.Values
@@ -216,4 +221,15 @@ func LoadCacheConfig() error {
 	configCache = data
 
 	return nil
+}
+
+func emptyConfig() ([]byte, error) {
+	cfg := &config.Config{}
+
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
 }

--- a/system/db/config.go
+++ b/system/db/config.go
@@ -166,6 +166,6 @@ func PutConfig(key string, value interface{}) error {
 
 // ConfigCache is a in-memory cache of the Configs for quicker lookups
 // 'key' is the JSON tag associated with the config field
-func ConfigCache(key string) string {
+func ConfigCache(key string) interface{} {
 	return configCache.Get(key)
 }

--- a/system/db/config.go
+++ b/system/db/config.go
@@ -108,6 +108,9 @@ func ConfigAll() ([]byte, error) {
 	val := &bytes.Buffer{}
 	err := store.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte("__config"))
+		if b == nil {
+			return fmt.Errorf("Error finding bucket: %s", "__config")
+		}
 		_, err := val.Write(b.Get([]byte("settings")))
 		if err != nil {
 			return err

--- a/system/db/config.go
+++ b/system/db/config.go
@@ -180,7 +180,10 @@ func LoadCacheConfig() error {
 		return err
 	}
 
-	fmt.Println(string(c))
+	if c == nil {
+		configCache = make(url.Values)
+		return nil
+	}
 
 	// convert json => map[string]interface{} => url.Values
 	var kv map[string]interface{}

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -450,13 +450,11 @@ func SortContent(namespace string) {
 		bname := []byte(namespace + "__sorted")
 		err := tx.DeleteBucket(bname)
 		if err != nil && err != bolt.ErrBucketNotFound {
-			fmt.Println("Error in DeleteBucket")
 			return err
 		}
 
 		b, err := tx.CreateBucketIfNotExists(bname)
 		if err != nil {
-			fmt.Println("Error in CreateBucketIfNotExists")
 			return err
 		}
 
@@ -465,7 +463,6 @@ func SortContent(namespace string) {
 			cid := fmt.Sprintf("%d:%d", i, posts[i].Time())
 			err = b.Put([]byte(cid), bb[i])
 			if err != nil {
-				fmt.Println("Error in Put")
 				return err
 			}
 		}

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -49,13 +49,13 @@ func update(ns, id string, data url.Values) (int, error) {
 		return 0, err
 	}
 
+	j, err := postToJSON(ns, data)
+	if err != nil {
+		return 0, err
+	}
+
 	err = store.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucketIfNotExists([]byte(ns + specifier))
-		if err != nil {
-			return err
-		}
-
-		j, err := postToJSON(ns, data)
 		if err != nil {
 			return err
 		}
@@ -134,6 +134,10 @@ func insert(ns string, data url.Values) (int, error) {
 		// store the slug,type:id in contentIndex if public content
 		if specifier == "" {
 			ci := tx.Bucket([]byte("__contentIndex"))
+			if ci == nil {
+				return bolt.ErrBucketNotFound
+			}
+
 			k := []byte(data.Get("slug"))
 			v := []byte(fmt.Sprintf("%s:%d", ns, effectedID))
 			err := ci.Put(k, v)
@@ -168,7 +172,12 @@ func DeleteContent(target string, data url.Values) error {
 	ns, id := t[0], t[1]
 
 	err := store.Update(func(tx *bolt.Tx) error {
-		err := tx.Bucket([]byte(ns)).Delete([]byte(id))
+		b := tx.Bucket([]byte(ns))
+		if b == nil {
+			return bolt.ErrBucketNotFound
+		}
+
+		err := b.Delete([]byte(id))
 		if err != nil {
 			return err
 		}
@@ -176,7 +185,12 @@ func DeleteContent(target string, data url.Values) error {
 		// if content has a slug, also delete it from __contentIndex
 		slug := data.Get("slug")
 		if slug != "" {
-			err := tx.Bucket([]byte("__contentIndex")).Delete([]byte(slug))
+			ci := tx.Bucket([]byte("__contentIndex"))
+			if ci == nil {
+				return bolt.ErrBucketNotFound
+			}
+
+			err := ci.Delete([]byte(slug))
 			if err != nil {
 				return err
 			}
@@ -212,6 +226,10 @@ func Content(target string) ([]byte, error) {
 	val := &bytes.Buffer{}
 	err := store.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(ns))
+		if b == nil {
+			return bolt.ErrBucketNotFound
+		}
+
 		_, err := val.Write(b.Get([]byte(id)))
 		if err != nil {
 			log.Println(err)
@@ -235,6 +253,9 @@ func ContentBySlug(slug string) (string, []byte, error) {
 	var t, id string
 	err := store.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte("__contentIndex"))
+		if b == nil {
+			return bolt.ErrBucketNotFound
+		}
 		idx := b.Get([]byte(slug))
 
 		if idx != nil {
@@ -248,6 +269,9 @@ func ContentBySlug(slug string) (string, []byte, error) {
 		}
 
 		c := tx.Bucket([]byte(t))
+		if c == nil {
+			return bolt.ErrBucketNotFound
+		}
 		_, err := val.Write(c.Get([]byte(id)))
 		if err != nil {
 			return err
@@ -267,9 +291,8 @@ func ContentAll(namespace string) [][]byte {
 	var posts [][]byte
 	store.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(namespace))
-
 		if b == nil {
-			return nil
+			return bolt.ErrBucketNotFound
 		}
 
 		numKeys := b.Stats().KeyN
@@ -313,7 +336,7 @@ func Query(namespace string, opts QueryOptions) (int, [][]byte) {
 	store.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(namespace))
 		if b == nil {
-			return nil
+			return bolt.ErrBucketNotFound
 		}
 
 		c := b.Cursor()
@@ -535,6 +558,9 @@ func checkSlugForDuplicate(slug string) (string, error) {
 	// check for existing slug in __contentIndex
 	err := store.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte("__contentIndex"))
+		if b == nil {
+			return bolt.ErrBucketNotFound
+		}
 		original := slug
 		exists := true
 		i := 0

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -55,21 +55,21 @@ func Init() {
 			}
 		}
 
-		err := LoadCacheConfig()
-		if err != nil {
-			return err
-		}
-
-		clientSecret := ConfigCache("client_secret").(string)
-
-		if clientSecret != "" {
-			jwt.Secret([]byte(clientSecret))
-		}
-
 		return nil
 	})
 	if err != nil {
 		log.Fatalln("Coudn't initialize db with buckets.", err)
+	}
+
+	err = LoadCacheConfig()
+	if err != nil {
+		log.Fatalln("Failed to load config cache.", err)
+	}
+
+	clientSecret := ConfigCache("client_secret").(string)
+
+	if clientSecret != "" {
+		jwt.Secret([]byte(clientSecret))
 	}
 
 	// invalidate cache on system start

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -1,10 +1,8 @@
 package db
 
 import (
-	"encoding/json"
 	"log"
 
-	"github.com/ponzu-cms/ponzu/system/admin/config"
 	"github.com/ponzu-cms/ponzu/system/item"
 
 	"github.com/boltdb/bolt"
@@ -57,18 +55,9 @@ func Init() {
 			}
 		}
 
-		// seed db with configs structure if not present
-		b := tx.Bucket([]byte("__config"))
-		if b.Get([]byte("settings")) == nil {
-			j, err := json.Marshal(&config.Config{})
-			if err != nil {
-				return err
-			}
-
-			err = b.Put([]byte("settings"), j)
-			if err != nil {
-				return err
-			}
+		err := LoadCacheConfig()
+		if err != nil {
+			return err
 		}
 
 		clientSecret := ConfigCache("client_secret").(string)

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -71,7 +71,7 @@ func Init() {
 			}
 		}
 
-		clientSecret := ConfigCache("client_secret")
+		clientSecret := ConfigCache("client_secret").(string)
 
 		if clientSecret != "" {
 			jwt.Secret([]byte(clientSecret))

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -92,6 +92,9 @@ func SystemInitComplete() bool {
 
 	err := store.View(func(tx *bolt.Tx) error {
 		users := tx.Bucket([]byte("__users"))
+		if users == nil {
+			return bolt.ErrBucketNotFound
+		}
 
 		err := users.ForEach(func(k, v []byte) error {
 			complete = true

--- a/system/tls/devcerts.go
+++ b/system/tls/devcerts.go
@@ -89,7 +89,7 @@ func setupDev() {
 	}
 
 	hosts := []string{"localhost", "0.0.0.0"}
-	domain := db.ConfigCache("domain")
+	domain := db.ConfigCache("domain").(string)
 	if domain != "" {
 		hosts = append(hosts, domain)
 	}

--- a/system/tls/enable.go
+++ b/system/tls/enable.go
@@ -70,7 +70,7 @@ func Enable() {
 	setup()
 
 	server := &http.Server{
-		Addr:      fmt.Sprintf(":%s", db.ConfigCache("https_port")),
+		Addr:      fmt.Sprintf(":%s", db.ConfigCache("https_port").(string)),
 		TLSConfig: &tls.Config{GetCertificate: m.GetCertificate},
 	}
 


### PR DESCRIPTION
This PR enables admins to disable/enable CORS and GZIP from within the admin CMS configuration page. Both are enabled by default.

Note: currently, the GZIP implementation is 100% on the fly, for every qualifying API endpoint request. This could add significant CPU usage, but dramatically decreases bandwidth. Will be considering other better implementations, but for now YMMV.

Possible optimizations:
- pooling gzip Writers vs. creating a new one for each response
- caching gzipped responses (in memory? on disk?) 
- enforcing size threshold (only gzip content larger than N bytes) 