### PR TITLE
[core] System backups (uploads, system.db, analytics.db)

### DIFF
--- a/system/admin/config/config.go
+++ b/system/admin/config/config.go
@@ -9,17 +9,26 @@ import (
 type Config struct {
 	item.Item
 
-	Name            string   `json:"name"`
-	Domain          string   `json:"domain"`
-	HTTPPort        string   `json:"http_port"`
-	HTTPSPort       string   `json:"https_port"`
-	AdminEmail      string   `json:"admin_email"`
-	ClientSecret    string   `json:"client_secret"`
-	Etag            string   `json:"etag"`
-	DisableCORS     bool     `json:"cors_disabled"`
-	DisableGZIP     bool     `json:"gzip_disabled"`
-	CacheInvalidate []string `json:"cache"`
+	Name                    string   `json:"name"`
+	Domain                  string   `json:"domain"`
+	HTTPPort                string   `json:"http_port"`
+	HTTPSPort               string   `json:"https_port"`
+	AdminEmail              string   `json:"admin_email"`
+	ClientSecret            string   `json:"client_secret"`
+	Etag                    string   `json:"etag"`
+	DisableCORS             bool     `json:"cors_disabled"`
+	DisableGZIP             bool     `json:"gzip_disabled"`
+	CacheInvalidate         []string `json:"cache"`
+	BackupBasicAuthUser     string   `json:"backup_basic_auth_user"`
+	BackupBasicAuthPassword string   `json:"backup_basic_auth_password"`
 }
+
+const (
+	dbBackupInfo = `
+		<p class="flow-text">Database Backup Credentials:</p>
+		<p>Add a user name and password to download a backup of your data via HTTP.</p>
+	`
+)
 
 // String partially implements item.Identifiable and overrides Item's String()
 func (c *Config) String() string { return c.Name }
@@ -95,6 +104,23 @@ func (c *Config) MarshalEditor() ([]byte, error) {
 				"label": "Invalidate cache on save",
 			}, map[string]string{
 				"invalidate": "Invalidate Cache",
+			}),
+		},
+		editor.Field{
+			View: []byte(dbBackupInfo),
+		},
+		editor.Field{
+			View: editor.Input("BackupBasicAuthUser", c, map[string]string{
+				"label":       "HTTP Basic Auth User",
+				"placeholder": "Enter a user name for Basic Auth access",
+				"type":        "text",
+			}),
+		},
+		editor.Field{
+			View: editor.Input("BackupBasicAuthPassword", c, map[string]string{
+				"label":       "HTTP Basic Auth Password",
+				"placeholder": "Enter a password for Basic Auth access",
+				"type":        "password",
 			}),
 		},
 	)

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ponzu-cms/ponzu/system/admin/upload"
 	"github.com/ponzu-cms/ponzu/system/admin/user"
 	"github.com/ponzu-cms/ponzu/system/api"
+	"github.com/ponzu-cms/ponzu/system/api/analytics"
 	"github.com/ponzu-cms/ponzu/system/db"
 	"github.com/ponzu-cms/ponzu/system/item"
 
@@ -186,6 +187,37 @@ func configHandler(res http.ResponseWriter, req *http.Request) {
 		res.WriteHeader(http.StatusMethodNotAllowed)
 	}
 
+}
+
+func backupHandler(res http.ResponseWriter, req *http.Request) {
+	switch req.URL.Query().Get("source") {
+	case "system":
+		err := db.Backup(res)
+		if err != nil {
+			log.Println("Failed to run backup on system:", err)
+			res.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+	case "analytics":
+		err := analytics.Backup(res)
+		if err != nil {
+			log.Println("Failed to run backup on analytics:", err)
+			res.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+	case "uploads":
+		err := upload.Backup(res)
+		if err != nil {
+			log.Println("Failed to run backup on uploads:", err)
+			res.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+	default:
+		res.WriteHeader(http.StatusBadRequest)
+	}
 }
 
 func configUsersHandler(res http.ResponseWriter, req *http.Request) {

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -21,11 +21,11 @@ import (
 	"github.com/ponzu-cms/ponzu/system/api"
 	"github.com/ponzu-cms/ponzu/system/db"
 	"github.com/ponzu-cms/ponzu/system/item"
-	"github.com/tidwall/gjson"
 
 	"github.com/gorilla/schema"
 	emailer "github.com/nilslice/email"
 	"github.com/nilslice/jwt"
+	"github.com/tidwall/gjson"
 )
 
 func adminHandler(res http.ResponseWriter, req *http.Request) {

--- a/system/admin/server.go
+++ b/system/admin/server.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/ponzu-cms/ponzu/system"
 	"github.com/ponzu-cms/ponzu/system/admin/user"
 	"github.com/ponzu-cms/ponzu/system/api"
 	"github.com/ponzu-cms/ponzu/system/db"
@@ -52,4 +53,7 @@ func Run() {
 	// through the editor will not load within the admin system.
 	uploadsDir := filepath.Join(pwd, "uploads")
 	http.Handle("/api/uploads/", api.Record(api.CORS(db.CacheControl(http.StripPrefix("/api/uploads/", http.FileServer(restrict(http.Dir(uploadsDir))))))))
+
+	// Database & uploads backup via HTTP route registered with Basic Auth middleware.
+	http.HandleFunc("/admin/backup", system.BasicAuth(backupHandler))
 }

--- a/system/admin/upload/backup.go
+++ b/system/admin/upload/backup.go
@@ -17,51 +17,85 @@ func Backup(res http.ResponseWriter) error {
 	ts := time.Now().Unix()
 	filename := fmt.Sprintf("uploads-%d.bak.tar.gz", ts)
 	tmp := os.TempDir()
+	backup := filepath.Join(tmp, filename)
 
 	// create uploads-{stamp}.bak.tar.gz
-	f, err := os.Create(filepath.Join(tmp, filename))
+	f, err := os.Create(backup)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 
 	// loop through directory and gzip files
 	// add all to uploads.bak.tar.gz tarball
 	gz := gzip.NewWriter(f)
 	tarball := tar.NewWriter(gz)
+
 	err = filepath.Walk("uploads", func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 
-		h := &tar.Header{
-			Name:    info.Name(),
-			Size:    info.Size(),
-			Mode:    int64(info.Mode()),
-			ModTime: info.ModTime(),
-		}
-
-		err = tarball.WriteHeader(h)
+		hdr, err := tar.FileInfoHeader(info, "")
 		if err != nil {
 			return err
 		}
 
-		src, err := os.Open(path)
+		hdr.Name = path
+
+		err = tarball.WriteHeader(hdr)
 		if err != nil {
 			return err
 		}
 
-		_, err = io.Copy(tarball, src)
+		if !info.IsDir() {
+			src, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			defer src.Close()
+			_, err = io.Copy(tarball, src)
+			if err != nil {
+				return err
+			}
 
-		return err
+			err = tarball.Flush()
+			if err != nil {
+				return err
+			}
+
+			err = gz.Flush()
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
 	})
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	err = gz.Close()
+	if err != nil {
+		return err
+	}
+	err = tarball.Close()
+	if err != nil {
+		return err
+	}
+	err = f.Close()
+	if err != nil {
+		return err
+	}
 
 	// write data to response
-	data, err := os.Open(filepath.Join(tmp, filename))
+	data, err := os.Open(backup)
 	if err != nil {
 		return err
 	}
 	defer data.Close()
+	defer os.Remove(backup)
 
 	disposition := `attachment; filename=%s`
 	info, err := data.Stat()
@@ -74,5 +108,6 @@ func Backup(res http.ResponseWriter) error {
 	res.Header().Set("Content-Length", fmt.Sprintf("%d", info.Size()))
 
 	_, err = io.Copy(res, data)
+
 	return err
 }

--- a/system/admin/upload/backup.go
+++ b/system/admin/upload/backup.go
@@ -1,0 +1,78 @@
+package upload
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Backup creates an archive of a project's uploads and writes it
+// to the response as a download
+func Backup(res http.ResponseWriter) error {
+	ts := time.Now().Unix()
+	filename := fmt.Sprintf("uploads-%d.bak.tar.gz", ts)
+	tmp := os.TempDir()
+
+	// create uploads-{stamp}.bak.tar.gz
+	f, err := os.Create(filepath.Join(tmp, filename))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// loop through directory and gzip files
+	// add all to uploads.bak.tar.gz tarball
+	gz := gzip.NewWriter(f)
+	tarball := tar.NewWriter(gz)
+	err = filepath.Walk("uploads", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		h := &tar.Header{
+			Name:    info.Name(),
+			Size:    info.Size(),
+			Mode:    int64(info.Mode()),
+			ModTime: info.ModTime(),
+		}
+
+		err = tarball.WriteHeader(h)
+		if err != nil {
+			return err
+		}
+
+		src, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+
+		_, err = io.Copy(tarball, src)
+
+		return err
+	})
+
+	// write data to response
+	data, err := os.Open(filepath.Join(tmp, filename))
+	if err != nil {
+		return err
+	}
+	defer data.Close()
+
+	disposition := `attachment; filename=%s`
+	info, err := data.Stat()
+	if err != nil {
+		return err
+	}
+
+	res.Header().Set("Content-Type", "application/octet-stream")
+	res.Header().Set("Content-Disposition", fmt.Sprintf(disposition, ts))
+	res.Header().Set("Content-Length", fmt.Sprintf("%d", info.Size()))
+
+	_, err = io.Copy(res, data)
+	return err
+}

--- a/system/api/analytics/backup.go
+++ b/system/api/analytics/backup.go
@@ -1,0 +1,26 @@
+package analytics
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/boltdb/bolt"
+)
+
+// Backup writes a snapshot of the analytics.db database to an HTTP response
+func Backup(res http.ResponseWriter) error {
+	err := store.View(func(tx *bolt.Tx) error {
+		ts := time.Now().Unix()
+		disposition := `attachment; filename="analytics-%d.db.bak"`
+
+		res.Header().Set("Content-Type", "application/octet-stream")
+		res.Header().Set("Content-Disposition", fmt.Sprintf(disposition, ts))
+		res.Header().Set("Content-Length", fmt.Sprintf("%d", int(tx.Size())))
+
+		_, err := tx.WriteTo(res)
+		return err
+	})
+
+	return err
+}

--- a/system/api/analytics/init.go
+++ b/system/api/analytics/init.go
@@ -43,13 +43,15 @@ const RANGE = 14
 func Record(req *http.Request) {
 	external := strings.Contains(req.URL.Path, "/external/")
 
+	ts := int64(time.Nanosecond) * time.Now().UnixNano() / int64(time.Millisecond)
+
 	r := apiRequest{
 		URL:        req.URL.String(),
 		Method:     req.Method,
 		Origin:     req.Header.Get("Origin"),
 		Proto:      req.Proto,
 		RemoteAddr: req.RemoteAddr,
-		Timestamp:  time.Now().Unix() * 1000,
+		Timestamp:  ts,
 		External:   external,
 	}
 

--- a/system/auth.go
+++ b/system/auth.go
@@ -1,0 +1,34 @@
+package system
+
+import (
+	"net/http"
+
+	"github.com/ponzu-cms/ponzu/system/db"
+)
+
+// BasicAuth adds HTTP Basic Auth check for requests that should implement it
+func BasicAuth(next http.HandlerFunc) http.HandlerFunc {
+	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		u := db.ConfigCache("backup_basic_auth_user").(string)
+		p := db.ConfigCache("backup_basic_auth_password").(string)
+
+		if u == "" || p == "" {
+			res.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		user, password, ok := req.BasicAuth()
+
+		if !ok {
+			res.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		if u != user || p != password {
+			res.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		next.ServeHTTP(res, req)
+	})
+}

--- a/system/db/backup.go
+++ b/system/db/backup.go
@@ -1,0 +1,26 @@
+package db
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/boltdb/bolt"
+)
+
+// Backup writes a snapshot of the system.db database to an HTTP response
+func Backup(res http.ResponseWriter) error {
+	err := store.View(func(tx *bolt.Tx) error {
+		ts := time.Now().Unix()
+		disposition := `attachment; filename="system-%d.db.bak"`
+
+		res.Header().Set("Content-Type", "application/octet-stream")
+		res.Header().Set("Content-Disposition", fmt.Sprintf(disposition, ts))
+		res.Header().Set("Content-Length", fmt.Sprintf("%d", int(tx.Size())))
+
+		_, err := tx.WriteTo(res)
+		return err
+	})
+
+	return err
+}


### PR DESCRIPTION
This PR provides a simple HTTP interface to create and download backups of your Ponzu databases and `uploads` directory. 

`/admin/backup?source={uploads,analytics,system}`

The endpoint requires Basic Auth, and the username and password must be provided by an admin in the Configuration section of the CMS. If there are no username or password credentials stored, the endpoint will return a 403 Forbidden. If the credentials provided are incorrect, a 401 Unauthorized is returned. 

The idea is that you will establish backup routines on a machine that could simply execute:
```bash
curl "https://user:pass@hostname?source=uploads" > uploads.bak.tar.gz
curl "https://user:pass@hostname?source=system" > system.db.bak
curl "https://user:pass@hostname?source=analytics" > analytics.db.bak
```
Uploads are gzipped and archived as a tarball, system and analytics db are sent as is since they're only ever a single file.