### PR TITLE
[core] implement http.Pusher on our composite gzip/response writer 

### DIFF
--- a/system/api/handlers.go
+++ b/system/api/handlers.go
@@ -332,7 +332,7 @@ func Gzip(next http.HandlerFunc) http.HandlerFunc {
 		if strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") {
 			// gzip response data
 			res.Header().Set("Content-Encoding", "gzip")
-			gzres := gzipResponseWriter{res, gzip.NewWriter(res)}
+			gzres := gzipResponseWriter{res, res.(http.Pusher), gzip.NewWriter(res)}
 
 			next.ServeHTTP(gzres, req)
 			return
@@ -344,6 +344,8 @@ func Gzip(next http.HandlerFunc) http.HandlerFunc {
 
 type gzipResponseWriter struct {
 	http.ResponseWriter
+	http.Pusher
+
 	gw *gzip.Writer
 }
 


### PR DESCRIPTION
Fix for #43 

`gzipResponseWriter` needed to implement `http.Pusher` and additionally set the `Accept-Encoding` header on the `http.PushOptions` struct argument.

Also removed `defer` from the call to `push` in handlers, since its likely that `Pushable` references are dependencies of their parent content. 