### PR TITLE
[core] Documentation typo fixes, adding new Hookable methods: BeforeAccept & AfterAccept

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ $ ponzu gen content review title:"string" body:"string" rating:"int" tags:"[]str
 ```
 
 The command above will generate the file `content/review.go` with boilerplate
-methods, as well as struct definition, and cooresponding field tags like:
+methods, as well as struct definition, and corresponding field tags like:
 
 ```go
 type Review struct {

--- a/cmd/ponzu/usage.go
+++ b/cmd/ponzu/usage.go
@@ -66,7 +66,7 @@ generate, gen, g <generator type (,...fields)>
 	$ ponzu gen content review title:"string" body:"string" rating:"int" tags:"[]string"
 
 	The command above will generate a file 'content/review.go' with boilerplate
-	methods, as well as struct definition, and cooresponding field tags like:
+	methods, as well as struct definition, and corresponding field tags like:
 
 	type Review struct {
 		Title  string   ` + "`json:" + `"title"` + "`" + `

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -4,7 +4,7 @@ This is a set of deployment scripts for starting up `ponzu-server` processes on
 system boot and run levels.
 
 To add one for a missing platform / OS, fork the ponzu repository and create a
-new pull request with the script inside a directory named by the cooresponding
+new pull request with the script inside a directory named by the corresponding
 init system.
 
 Questions? Reach out to [@ponzu_cms](https://twitter.com/ponzu_cms) on Twitter, 

--- a/system/item/item.go
+++ b/system/item/item.go
@@ -42,6 +42,9 @@ type Sortable interface {
 // to the different lifecycles/events a struct may encounter. Item implements
 // Hookable with no-ops so our user can override only whichever ones necessary.
 type Hookable interface {
+	BeforeAccept(http.ResponseWriter, *http.Request) error
+	AfterAccept(http.ResponseWriter, *http.Request) error
+
 	BeforeSave(http.ResponseWriter, *http.Request) error
 	AfterSave(http.ResponseWriter, *http.Request) error
 
@@ -119,6 +122,16 @@ func (i Item) UniqueID() uuid.UUID {
 // partially implements the Identifiable interface
 func (i Item) String() string {
 	return fmt.Sprintf("Item ID: %s", i.UniqueID())
+}
+
+// BeforeAccept is a no-op to ensure structs which embed Item implement Hookable
+func (i Item) BeforeAccept(res http.ResponseWriter, req *http.Request) error {
+	return nil
+}
+
+// AfterAccept is a no-op to ensure structs which embed Item implement Hookable
+func (i Item) AfterAccept(res http.ResponseWriter, req *http.Request) error {
+	return nil
 }
 
 // BeforeSave is a no-op to ensure structs which embed Item implement Hookable


### PR DESCRIPTION
Another thank you to @ferhatelmas for the typo fixes!

In addition, I have added two new methods to the `item.Hookable` interface:

```go
BeforeAccept(http.ResponseWriter, *http.Request) error
AfterAccept(http.ResponseWriter, *http.Request) error
```

These add helpful functionality when needing to react to the one-time action of accepting content from an external source. I personally needed to do this and had previously hacked `BeforeSave` (which is called AFTER `BeforeAccept` and `Accept`), to look for and set a flag which indicated that content was newly saved to the CMS.  

This is being merged into master on the current release.