### PR TITLE
[core] Adding support to omit fields from json response, minor code reorganization

### DIFF
--- a/system/api/cors.go
+++ b/system/api/cors.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"log"
+	"net/http"
+	"net/url"
+
+	"github.com/ponzu-cms/ponzu/system/db"
+)
+
+// sendPreflight is used to respond to a cross-origin "OPTIONS" request
+func sendPreflight(res http.ResponseWriter) {
+	res.Header().Set("Access-Control-Allow-Headers", "Accept, Authorization, Content-Type")
+	res.Header().Set("Access-Control-Allow-Origin", "*")
+	res.WriteHeader(200)
+	return
+}
+
+func responseWithCORS(res http.ResponseWriter, req *http.Request) (http.ResponseWriter, bool) {
+	if db.ConfigCache("cors_disabled").(bool) == true {
+		// check origin matches config domain
+		domain := db.ConfigCache("domain").(string)
+		origin := req.Header.Get("Origin")
+		u, err := url.Parse(origin)
+		if err != nil {
+			log.Println("Error parsing URL from request Origin header:", origin)
+			return res, false
+		}
+
+		// hack to get dev environments to bypass cors since u.Host (below) will
+		// be empty, based on Go's url.Parse function
+		if domain == "localhost" {
+			domain = ""
+		}
+		origin = u.Host
+
+		// currently, this will check for exact match. will need feedback to
+		// determine if subdomains should be allowed or allow multiple domains
+		// in config
+		if origin == domain {
+			// apply limited CORS headers and return
+			res.Header().Set("Access-Control-Allow-Headers", "Accept, Authorization, Content-Type")
+			res.Header().Set("Access-Control-Allow-Origin", domain)
+			return res, true
+		}
+
+		// disallow request
+		res.WriteHeader(http.StatusForbidden)
+		return res, false
+	}
+
+	// apply full CORS headers and return
+	res.Header().Set("Access-Control-Allow-Headers", "Accept, Authorization, Content-Type")
+	res.Header().Set("Access-Control-Allow-Origin", "*")
+
+	return res, true
+}
+
+// CORS wraps a HandlerFunc to respond to OPTIONS requests properly
+func CORS(next http.HandlerFunc) http.HandlerFunc {
+	return db.CacheControl(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res, cors := responseWithCORS(res, req)
+		if !cors {
+			return
+		}
+
+		if req.Method == http.MethodOptions {
+			sendPreflight(res)
+			return
+		}
+
+		next.ServeHTTP(res, req)
+	}))
+}

--- a/system/api/gzip.go
+++ b/system/api/gzip.go
@@ -48,6 +48,10 @@ func (gzw gzipResponseWriter) Write(p []byte) (int, error) {
 }
 
 func (gzw gzipResponseWriter) Push(target string, opts *http.PushOptions) error {
+	if gzw.pusher == nil {
+		return nil
+	}
+
 	if opts == nil {
 		opts = &http.PushOptions{
 			Header: make(http.Header),

--- a/system/api/gzip.go
+++ b/system/api/gzip.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"compress/gzip"
+	"net/http"
+	"strings"
+
+	"github.com/ponzu-cms/ponzu/system/db"
+)
+
+// Gzip wraps a HandlerFunc to compress responses when possible
+func Gzip(next http.HandlerFunc) http.HandlerFunc {
+	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if db.ConfigCache("gzip_disabled").(bool) == true {
+			next.ServeHTTP(res, req)
+			return
+		}
+
+		// check if req header content-encoding supports gzip
+		if strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") {
+			// gzip response data
+			res.Header().Set("Content-Encoding", "gzip")
+			var gzres gzipResponseWriter
+			if pusher, ok := res.(http.Pusher); ok {
+				gzres = gzipResponseWriter{res, pusher, gzip.NewWriter(res)}
+			} else {
+				gzres = gzipResponseWriter{res, nil, gzip.NewWriter(res)}
+			}
+
+			next.ServeHTTP(gzres, req)
+			return
+		}
+
+		next.ServeHTTP(res, req)
+	})
+}
+
+type gzipResponseWriter struct {
+	http.ResponseWriter
+	pusher http.Pusher
+
+	gw *gzip.Writer
+}
+
+func (gzw gzipResponseWriter) Write(p []byte) (int, error) {
+	defer gzw.gw.Close()
+	return gzw.gw.Write(p)
+}
+
+func (gzw gzipResponseWriter) Push(target string, opts *http.PushOptions) error {
+	if opts == nil {
+		opts = &http.PushOptions{
+			Header: make(http.Header),
+		}
+	}
+
+	opts.Header.Set("Accept-Encoding", "gzip")
+
+	return gzw.pusher.Push(target, opts)
+}

--- a/system/api/handlers.go
+++ b/system/api/handlers.go
@@ -90,7 +90,7 @@ func contentsHandler(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	j, err = omit(it(), res, req, &j)
+	j, err = omit(it(), j)
 	if err != nil {
 		res.WriteHeader(http.StatusInternalServerError)
 		return
@@ -139,7 +139,7 @@ func contentHandler(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	j, err = omit(pt(), res, req, &j)
+	j, err = omit(pt(), j)
 	if err != nil {
 		res.WriteHeader(http.StatusInternalServerError)
 		return
@@ -182,7 +182,7 @@ func contentHandlerBySlug(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	j, err = omit(it(), res, req, &j)
+	j, err = omit(it(), j)
 	if err != nil {
 		res.WriteHeader(http.StatusInternalServerError)
 		return

--- a/system/api/hide.go
+++ b/system/api/hide.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/ponzu-cms/ponzu/system/item"
+)
+
+func hide(it interface{}, res http.ResponseWriter, req *http.Request) bool {
+	// check if should be hidden
+	if h, ok := it.(item.Hideable); ok {
+		err := h.Hide(res, req)
+		if err == item.ErrAllowHiddenItem {
+			return false
+		}
+
+		if err != nil {
+			res.WriteHeader(http.StatusInternalServerError)
+			return true
+		}
+
+		res.WriteHeader(http.StatusNotFound)
+		return true
+	}
+
+	return false
+}

--- a/system/api/json.go
+++ b/system/api/json.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+func fmtJSON(data ...json.RawMessage) ([]byte, error) {
+	var msg = []json.RawMessage{}
+	for _, d := range data {
+		msg = append(msg, d)
+	}
+
+	resp := map[string][]json.RawMessage{
+		"data": msg,
+	}
+
+	var buf = &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	err := enc.Encode(resp)
+	if err != nil {
+		log.Println("Failed to encode data to JSON:", err)
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func toJSON(data []string) ([]byte, error) {
+	var buf = &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	resp := map[string][]string{
+		"data": data,
+	}
+
+	err := enc.Encode(resp)
+	if err != nil {
+		log.Println("Failed to encode data to JSON:", err)
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// sendData should be used any time you want to communicate
+// data back to a foreign client
+func sendData(res http.ResponseWriter, req *http.Request, data []byte) {
+	res.Header().Set("Content-Type", "application/json")
+	res.Header().Set("Vary", "Accept-Encoding")
+
+	_, err := res.Write(data)
+	if err != nil {
+		log.Println("Error writing to response in sendData")
+	}
+}

--- a/system/api/omit.go
+++ b/system/api/omit.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/ponzu-cms/ponzu/system/item"
+
+	"github.com/tidwall/sjson"
+)
+
+func omit(it interface{}, res http.ResponseWriter, req *http.Request, data *[]byte) ([]byte, error) {
+	// is it Omittable
+	om, ok := it.(item.Omittable)
+	if !ok {
+		return *data, nil
+	}
+
+	// get fields to omit from json data
+	fields := om.Omit()
+
+	// remove each field from json, all responses contain json object(s) in top-level "data" array
+	var omitted []byte
+	for i := range fields {
+		var err error
+		omitted, err = sjson.DeleteBytes(*data, "data."+fields[i])
+		if err != nil {
+			log.Println("Erorr omitting field:", fields[i], "from item.Omittable:", it)
+			return nil, err
+		}
+	}
+
+	return omitted, nil
+}

--- a/system/api/omit.go
+++ b/system/api/omit.go
@@ -2,30 +2,33 @@ package api
 
 import (
 	"log"
-	"net/http"
 
 	"github.com/ponzu-cms/ponzu/system/item"
 
 	"github.com/tidwall/sjson"
 )
 
-func omit(it interface{}, res http.ResponseWriter, req *http.Request, data *[]byte) ([]byte, error) {
+func omit(it interface{}, data []byte) ([]byte, error) {
 	// is it Omittable
 	om, ok := it.(item.Omittable)
 	if !ok {
-		return *data, nil
+		return data, nil
 	}
 
+	return omitFields(om, data, "data.0.")
+}
+
+func omitFields(om item.Omittable, data []byte, pathPrefix string) ([]byte, error) {
 	// get fields to omit from json data
 	fields := om.Omit()
 
 	// remove each field from json, all responses contain json object(s) in top-level "data" array
-	var omitted []byte
+	var omitted = data
 	for i := range fields {
 		var err error
-		omitted, err = sjson.DeleteBytes(*data, "data."+fields[i])
+		omitted, err = sjson.DeleteBytes(omitted, pathPrefix+fields[i])
 		if err != nil {
-			log.Println("Erorr omitting field:", fields[i], "from item.Omittable:", it)
+			log.Println("Erorr omitting field:", fields[i], "from item.Omittable:", om)
 			return nil, err
 		}
 	}

--- a/system/api/push.go
+++ b/system/api/push.go
@@ -23,7 +23,7 @@ func push(res http.ResponseWriter, req *http.Request, pt func() interface{}, dat
 			for i := range values {
 				val := values[i]
 				val.ForEach(func(k, v gjson.Result) bool {
-					err := pusher.Push(req.URL.Path+v.String(), nil)
+					err := pusher.Push(v.String(), nil)
 					if err != nil {
 						log.Println("Error during Push of value:", v.String())
 					}

--- a/system/api/record.go
+++ b/system/api/record.go
@@ -1,0 +1,16 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/ponzu-cms/ponzu/system/api/analytics"
+)
+
+// Record wraps a HandlerFunc to record API requests for analytical purposes
+func Record(next http.HandlerFunc) http.HandlerFunc {
+	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		go analytics.Record(req)
+
+		next.ServeHTTP(res, req)
+	})
+}

--- a/system/item/item.go
+++ b/system/item/item.go
@@ -71,6 +71,14 @@ type Pushable interface {
 	Push() []string
 }
 
+// Omittable lets a user define certin fields within a content struct to remove
+// from an API response. Helpful when you want data in the CMS, but not entirely
+// shown or available from the content API. All items in the slice should be the
+// json tag names of the struct fields to which they coorespond.
+type Omittable interface {
+	Omit() []string
+}
+
 // Item should only be embedded into content type structs.
 type Item struct {
 	UUID      uuid.UUID `json:"uuid"`


### PR DESCRIPTION
This PR adds support to selectively omit arbitrary fields from a content API JSON response. Made accessible to Ponzu content types via the `item.Omittable` interface:

```go
type Omittable interface {
    Omit() []string
}
```

The `[]string` returned by `Omit` is similar to the one returned by `item.Pushable#Push`, which contains the string names of the JSON tags for their corresponding struct fields. 

Additionally, there is some minor code reorganization to set a new pattern for adding new interfaces and their implementations to the API response code. Once an interface is added, like `item.Omittable`, its implementation should be done in a new file (or one whose domain/scope is similar) within the `system/api` package. The application of the interface should then be added in the handler at the appropriate location. 

Lastly, there is a fix for #58 which was occasionally causing a panic when `gzipResponseWriter#Push` was called, although will need to verify this fixes the problem with @bketelsen, who originally identified the issue.