### PR TITLE
Fix Windows build & run

### DIFF
--- a/cmd/ponzu/main.go
+++ b/cmd/ponzu/main.go
@@ -146,7 +146,7 @@ func main() {
 			services = "admin,api"
 		}
 
-		serve := exec.Command(GetPonzuServerBuildOutputFileName(),
+		serve := exec.Command(buildOutputName(),
 			fmt.Sprintf("--port=%d", port),
 			fmt.Sprintf("--httpsport=%d", httpsport),
 			addTLS,

--- a/cmd/ponzu/main.go
+++ b/cmd/ponzu/main.go
@@ -146,7 +146,7 @@ func main() {
 			services = "admin,api"
 		}
 
-		serve := exec.Command("./ponzu-server",
+		serve := exec.Command(GetPonzuServerBuildOutputFileName(),
 			fmt.Sprintf("--port=%d", port),
 			fmt.Sprintf("--httpsport=%d", httpsport),
 			addTLS,

--- a/cmd/ponzu/options.go
+++ b/cmd/ponzu/options.go
@@ -302,7 +302,7 @@ func buildPonzuServer(args []string) error {
 	}
 
 	// execute go build -o ponzu-cms cmd/ponzu/*.go
-	buildOptions := []string{"build", "-o", GetPonzuServerBuildOutputFileName()}
+	buildOptions := []string{"build", "-o", buildOutputName()}
 	cmdBuildFiles := []string{"main.go", "options.go", "generate.go", "usage.go"}
 	var cmdBuildFilePaths []string
 	for _, file := range cmdBuildFiles {

--- a/cmd/ponzu/options.go
+++ b/cmd/ponzu/options.go
@@ -302,7 +302,7 @@ func buildPonzuServer(args []string) error {
 	}
 
 	// execute go build -o ponzu-cms cmd/ponzu/*.go
-	buildOptions := []string{"build", "-o", "ponzu-server"}
+	buildOptions := []string{"build", "-o", GetPonzuServerBuildOutputFileName()}
 	cmdBuildFiles := []string{"main.go", "options.go", "generate.go", "usage.go"}
 	var cmdBuildFilePaths []string
 	for _, file := range cmdBuildFiles {

--- a/cmd/ponzu/paths.go
+++ b/cmd/ponzu/paths.go
@@ -2,9 +2,9 @@ package main
 
 import "runtime"
 
-// GetPonzuServerBuildOutputFileName returns de correct
-// ponzu-server file name based on the host Operating System
-func GetPonzuServerBuildOutputFileName() string {
+// buildOutputName returns the correct ponzu-server file name 
+// based on the host Operating System
+func buildOutputName() string {
 	if runtime.GOOS == "windows" {
 		return "ponzu-server.exe"
 	}

--- a/cmd/ponzu/paths.go
+++ b/cmd/ponzu/paths.go
@@ -1,0 +1,12 @@
+package main
+
+import "runtime"
+
+// GetPonzuServerBuildOutputFileName returns de correct
+// ponzu-server file name based on the host Operating System
+func GetPonzuServerBuildOutputFileName() string {
+	if runtime.GOOS == "windows" {
+		return "ponzu-server.exe"
+	}
+	return "ponzu-server"
+}


### PR DESCRIPTION
Created a file called 'paths.go', this way paths are separated from main logic, and also, will be able to use go's conditional building if we need it in any time (based on file names).