### PR TITLE
[core] fix path location for cross-platform compatibility

### DIFF
--- a/cmd/ponzu/main.go
+++ b/cmd/ponzu/main.go
@@ -147,9 +147,8 @@ func main() {
 			services = "admin,api"
 		}
 
-		path := buildOutputPath()
 		name := buildOutputName()
-		buildPathName := strings.Join([]string{path, name}, string(filepath.Separator))
+		buildPathName := strings.Join([]string{".", name}, string(filepath.Separator))
 		serve := exec.Command(buildPathName,
 			fmt.Sprintf("--port=%d", port),
 			fmt.Sprintf("--httpsport=%d", httpsport),

--- a/cmd/ponzu/paths.go
+++ b/cmd/ponzu/paths.go
@@ -11,14 +11,3 @@ func buildOutputName() string {
 
 	return "ponzu-server"
 }
-
-// buildOutputPath returns the correct path to the ponzu-server binary
-// built, based on the host Operating System. This is necessary so that
-// the UNIX-y systems know to look in the current directory, and not the $PATH
-func buildOutputPath() string {
-	if runtime.GOOS == "windows" {
-		return ""
-	}
-
-	return "."
-}


### PR DESCRIPTION
Again, thank you to @Sirikon for the help identifying and fixing these issues.

Now, the built output binary/executable of `$ ponzu build` is correctly located per OS filesystem differences when running `$ ponzu run`
