### PR TITLE
ponzu add <addon URI>

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,19 @@ $ ponzu upgrade
 
 ---
 
+### add, a
+
+Downloads an addon to GOPATH/src and copys it to the Ponzu project's ./addons directory.
+
+Example:
+```bash
+$ ponzu add github.com/bosssauce/fbscheduler
+```
+
+Errors will be reported, but successful add commands return nothing.
+
+---
+
 ### version, v
 
 Prints the version of Ponzu your project is using. Must be called from within a 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ $ ponzu upgrade
 ### add, a
 
 Downloads an addon to GOPATH/src and copys it to the Ponzu project's ./addons directory.
+Must be called from within a Ponzu project directory.
 
 Example:
 ```bash

--- a/cmd/ponzu/add.go
+++ b/cmd/ponzu/add.go
@@ -2,14 +2,15 @@ package main
 
 import (
 	"errors"
-	"log"
+	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 )
 
-// Use `go get` to download addon and add to $GOPATH/src, useful
+// use `go get` to download addon and add to $GOPATH/src, useful
 // for IDE auto-import and code completion, then copy entire directory
 // tree to project's ./addons folder
 func getAddon(args []string) error {
@@ -25,35 +26,32 @@ func getAddon(args []string) error {
 
 	err := get.Start()
 	if err != nil {
-		addError(err)
+		return addError(err)
 	}
 	err = get.Wait()
 	if err != nil {
-		addError(err)
+		return addError(err)
 	}
 
-	// Copy to ./addons folder
+	// copy to ./addons folder
 	// GOPATH can be a list delimited by ":" on Linux or ";" on Windows
 	// `go get` uses the first, this should parse out the first whatever the OS
 	gopath := resolveGOPATH()
 
 	pwd, err := os.Getwd()
 	if err != nil {
-		addError(err)
+		return addError(err)
 	}
 
 	src := filepath.Join(gopath, "src", addonPath)
-	dest := filepath.Join(pwd, "addons", addonPath)
-	log.Println(dest)
 
-	err = os.Mkdir(dest, os.ModeDir|os.ModePerm)
+	// Need to strip the addon name for copyAll?
+	last := filepath.Base(addonPath)
+	dest := filepath.Join(pwd, "addons", strings.Replace(addonPath, last, "", 1))
+
+	err = replicateAll(src, dest)
 	if err != nil {
-		addError(err)
-	}
-	err = copyAll(src, dest)
-	if err != nil {
-		log.Println(err)
-		//addError(err)
+		return addError(err)
 	}
 	return nil
 }
@@ -70,7 +68,110 @@ func resolveGOPATH() string {
 	return gopath
 }
 
-// error return
+// this is distinct from copyAll() in that files are copied, not moved,
+// since we also need them to remain in $GOPATH/src
+// thanks to @markc of stack overflow for the copyFile and copyFileContents functions
+func replicateAll(src, dst string) error {
+	err := filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		sep := string(filepath.Separator)
+
+		// base == the ponzu project dir + string(filepath.Separator)
+		parts := strings.Split(src, sep)
+		base := strings.Join(parts[:len(parts)-1], sep)
+		base += sep
+
+		target := filepath.Join(dst, path[len(base):])
+
+		// if its a directory, make dir in dst
+		if info.IsDir() {
+			err := os.MkdirAll(target, os.ModeDir|os.ModePerm)
+			if err != nil {
+				return err
+			}
+		} else {
+			// if its a file, copy file to dir of dst
+			err = copyFile(path, target)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// copyFile copies a file from src to dst. if src and dst files exist, and are
+// the same, then return success. Otherise, attempt to create a hard link
+// between the two files. If that fail, copy the file contents from src to dst.
+// thanks to Stack Overflow
+func copyFile(src, dst string) (err error) {
+	sfi, err := os.Stat(src)
+	if err != nil {
+		return
+	}
+	if !sfi.Mode().IsRegular() {
+		// cannot copy non-regular files (e.g., directories,
+		// symlinks, devices, etc.)
+		return fmt.Errorf("CopyFile: non-regular source file %s (%q)", sfi.Name(), sfi.Mode().String())
+	}
+	dfi, err := os.Stat(dst)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return
+		}
+	} else {
+		if !(dfi.Mode().IsRegular()) {
+			return fmt.Errorf("CopyFile: non-regular destination file %s (%q)", dfi.Name(), dfi.Mode().String())
+		}
+		if os.SameFile(sfi, dfi) {
+			return
+		}
+	}
+	if err = os.Link(src, dst); err == nil {
+		return
+	}
+	err = copyFileContents(src, dst)
+	return
+}
+
+// copyFileContents copies the contents of the file named src to the file named
+// by dst. The file will be created if it does not already exist. If the
+// destination file exists, all it's contents will be replaced by the contents
+// of the source file.
+// Thanks for Stack Overflow
+func copyFileContents(src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return
+	}
+	defer func() {
+		cerr := out.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+	if _, err = io.Copy(out, in); err != nil {
+		return
+	}
+	err = out.Sync()
+	return
+}
+
+// generic error return
 func addError(err error) error {
 	return errors.New("Ponzu add failed. " + "\n" + err.Error())
 }

--- a/cmd/ponzu/add.go
+++ b/cmd/ponzu/add.go
@@ -1,0 +1,5 @@
+package main
+
+func getAddon(args []string) error {
+	return nil
+}

--- a/cmd/ponzu/add.go
+++ b/cmd/ponzu/add.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,11 +13,6 @@ import (
 // for IDE auto-import and code completion, then copy entire directory
 // tree to project's ./addons folder
 func getAddon(args []string) error {
-
-	// error return
-	errorFunc := func(err error) error {
-		return errors.New("Ponzu add failed. " + "\n" + err.Error())
-	}
 
 	var cmdOptions []string
 	var addonPath = args[1]
@@ -29,11 +25,11 @@ func getAddon(args []string) error {
 
 	err := get.Start()
 	if err != nil {
-		errorFunc(err)
+		addError(err)
 	}
 	err = get.Wait()
 	if err != nil {
-		errorFunc(err)
+		addError(err)
 	}
 
 	// Copy to ./addons folder
@@ -43,15 +39,17 @@ func getAddon(args []string) error {
 
 	pwd, err := os.Getwd()
 	if err != nil {
-		errorFunc(err)
+		addError(err)
 	}
 
 	src := filepath.Join(gopath, addonPath)
 	dest := filepath.Join(pwd, "addons", addonPath)
+	log.Println(dest)
 
+	err = os.Mkdir(dest, os.ModeDir|os.ModePerm)
 	err = copyAll(src, dest)
 	if err != nil {
-		errorFunc(err)
+		addError(err)
 	}
 	return nil
 }
@@ -66,4 +64,9 @@ func resolveGOPATH() string {
 	gopaths = strings.Split(envGOPATH, ";")
 	gopath = gopaths[0]
 	return gopath
+}
+
+// error return
+func addError(err error) error {
+	return errors.New("Ponzu add failed. " + "\n" + err.Error())
 }

--- a/cmd/ponzu/add.go
+++ b/cmd/ponzu/add.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -42,10 +41,13 @@ func getAddon(args []string) error {
 	// `go get` uses the first, this should parse out the first whatever the OS
 	gopath := resolveGOPATH()
 
+	pwd, err := os.Getwd()
+	if err != nil {
+		errorFunc(err)
+	}
+
 	src := filepath.Join(gopath, addonPath)
-	log.Println(src)
-	dest := filepath.Join("addons", addonPath)
-	log.Println(dest)
+	dest := filepath.Join(pwd, "addons", addonPath)
 
 	err = copyAll(src, dest)
 	if err != nil {

--- a/cmd/ponzu/add.go
+++ b/cmd/ponzu/add.go
@@ -39,18 +39,27 @@ func getAddon(args []string) error {
 	// Copy to ./addons folder
 	// GOPATH can be a list delimited by ":" on Linux or ";" on Windows
 	// `go get` uses the first, this should parse out the first whatever the OS
-	envGOPATH := os.Getenv("GOPATH")
-	gopaths := strings.Split(envGOPATH, ":")
-	gopath := gopaths[0]
-	gopaths = strings.Split(envGOPATH, ";")
-	gopath = gopaths[0]
+	gopath := resolveGOPATH()
 
 	src := filepath.Join(gopath, addonPath)
-	dest := filepath.Join("./addons", addonPath)
+	dest := filepath.Join("addons", addonPath)
 
 	err = copyAll(src, dest)
 	if err != nil {
 		errorFunc(err)
 	}
 	return nil
+}
+
+// GOPATH can be a list delimited by ":" on Linux or ";" on Windows
+// `go get` uses saves packages to the first entry, so this function
+// should parse out the first whatever the OS
+func resolveGOPATH() string {
+
+	envGOPATH := os.Getenv("GOPATH")
+	gopaths := strings.Split(envGOPATH, ":")
+	gopath := gopaths[0]
+	gopaths = strings.Split(envGOPATH, ";")
+	gopath = gopaths[0]
+	return gopath
 }

--- a/cmd/ponzu/add.go
+++ b/cmd/ponzu/add.go
@@ -42,14 +42,18 @@ func getAddon(args []string) error {
 		addError(err)
 	}
 
-	src := filepath.Join(gopath, addonPath)
+	src := filepath.Join(gopath, "src", addonPath)
 	dest := filepath.Join(pwd, "addons", addonPath)
 	log.Println(dest)
 
 	err = os.Mkdir(dest, os.ModeDir|os.ModePerm)
-	err = copyAll(src, dest)
 	if err != nil {
 		addError(err)
+	}
+	err = copyAll(src, dest)
+	if err != nil {
+		log.Println(err)
+		//addError(err)
 	}
 	return nil
 }

--- a/cmd/ponzu/add.go
+++ b/cmd/ponzu/add.go
@@ -37,9 +37,8 @@ func getAddon(args []string) error {
 	}
 
 	// Copy to ./addons folder
-
 	// GOPATH can be a list delimited by ":" on Linux or ";" on Windows
-	// go get uses the first, this should parse out the first whatever the OS
+	// `go get` uses the first, this should parse out the first whatever the OS
 	envGOPATH := os.Getenv("GOPATH")
 	gopaths := strings.Split(envGOPATH, ":")
 	gopath := gopaths[0]

--- a/cmd/ponzu/add.go
+++ b/cmd/ponzu/add.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -42,7 +43,9 @@ func getAddon(args []string) error {
 	gopath := resolveGOPATH()
 
 	src := filepath.Join(gopath, addonPath)
+	log.Println(src)
 	dest := filepath.Join("addons", addonPath)
+	log.Println(dest)
 
 	err = copyAll(src, dest)
 	if err != nil {
@@ -55,7 +58,6 @@ func getAddon(args []string) error {
 // `go get` uses saves packages to the first entry, so this function
 // should parse out the first whatever the OS
 func resolveGOPATH() string {
-
 	envGOPATH := os.Getenv("GOPATH")
 	gopaths := strings.Split(envGOPATH, ":")
 	gopath := gopaths[0]

--- a/cmd/ponzu/add.go
+++ b/cmd/ponzu/add.go
@@ -1,5 +1,57 @@
 package main
 
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Use `go get` to download addon and add to $GOPATH/src, useful
+// for IDE auto-import and code completion, then copy entire directory
+// tree to project's ./addons folder
 func getAddon(args []string) error {
+
+	// error return
+	errorFunc := func(err error) error {
+		return errors.New("Ponzu add failed. " + "\n" + err.Error())
+	}
+
+	var cmdOptions []string
+	var addonPath = args[1]
+
+	// Go get
+	cmdOptions = append(cmdOptions, addonPath)
+	get := exec.Command(gocmd, cmdOptions...)
+	get.Stderr = os.Stderr
+	get.Stdout = os.Stdout
+
+	err := get.Start()
+	if err != nil {
+		errorFunc(err)
+	}
+	err = get.Wait()
+	if err != nil {
+		errorFunc(err)
+	}
+
+	// Copy to ./addons folder
+
+	// GOPATH can be a list delimited by ":" on Linux or ";" on Windows
+	// go get uses the first, this should parse out the first whatever the OS
+	envGOPATH := os.Getenv("GOPATH")
+	gopaths := strings.Split(envGOPATH, ":")
+	gopath := gopaths[0]
+	gopaths = strings.Split(envGOPATH, ";")
+	gopath = gopaths[0]
+
+	src := filepath.Join(gopath, addonPath)
+	dest := filepath.Join("./addons", addonPath)
+
+	err = copyAll(src, dest)
+	if err != nil {
+		errorFunc(err)
+	}
 	return nil
 }

--- a/cmd/ponzu/add.go
+++ b/cmd/ponzu/add.go
@@ -22,7 +22,7 @@ func getAddon(args []string) error {
 	var addonPath = args[1]
 
 	// Go get
-	cmdOptions = append(cmdOptions, addonPath)
+	cmdOptions = append(cmdOptions, "get", addonPath)
 	get := exec.Command(gocmd, cmdOptions...)
 	get.Stderr = os.Stderr
 	get.Stdout = os.Stdout

--- a/cmd/ponzu/main.go
+++ b/cmd/ponzu/main.go
@@ -88,6 +88,10 @@ func main() {
 		case "version", "v":
 			fmt.Println(usageVersion)
 			os.Exit(0)
+
+		case "add", "a":
+			fmt.Println(usageAdd)
+			os.Exit(0)
 		}
 
 	case "new":
@@ -263,6 +267,13 @@ func main() {
 
 		default:
 			fmt.Println("Input not recognized. No upgrade made. Answer as 'y' or 'n' only.")
+		}
+
+	case "add", "a":
+		// expecting two args, add and the go gettable package uri
+		if len(args) < 2 {
+			fmt.Println(usageAdd)
+			os.Exit(0)
 		}
 
 	case "":

--- a/cmd/ponzu/main.go
+++ b/cmd/ponzu/main.go
@@ -276,11 +276,11 @@ func main() {
 			os.Exit(0)
 		}
 
-		/*err := getAddon(args)
+		err := getAddon(args)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
-		}*/
+		}
 
 	case "":
 		fmt.Println(usage)

--- a/cmd/ponzu/main.go
+++ b/cmd/ponzu/main.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	usage = usageHeader + usageNew + usageGenerate +
-		usageBuild + usageRun + usageUpgrade + usageVersion
+		usageBuild + usageRun + usageUpgrade + usageAdd + usageVersion
 	port      int
 	httpsport int
 	https     bool
@@ -275,6 +275,12 @@ func main() {
 			fmt.Println(usageAdd)
 			os.Exit(0)
 		}
+
+		/*err := getAddon(args)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}*/
 
 	case "":
 		fmt.Println(usage)

--- a/cmd/ponzu/options.go
+++ b/cmd/ponzu/options.go
@@ -305,7 +305,7 @@ func buildPonzuServer(args []string) error {
 	buildOptions := []string{"build", "-o", buildOutputName()}
 	cmdBuildFiles := []string{
 		"main.go", "options.go", "generate.go",
-		"usage.go", "paths.go",
+		"usage.go", "paths.go", "add.go",
 	}
 	var cmdBuildFilePaths []string
 	for _, file := range cmdBuildFiles {

--- a/cmd/ponzu/usage.go
+++ b/cmd/ponzu/usage.go
@@ -163,9 +163,9 @@ var usageVersion = `
 `
 
 var usageAdd = `
-[--cli] add, a <addon URI>
+add, a <import path>
 
-	Downloads addon from specified URI to $GOPATH/src and copys it to the
+	Downloads addon from specified import path to $GOPATH/src and copys it to the
 	current project's ./addons directory. Must be called from within a 
 	Ponzu project directory.
 

--- a/cmd/ponzu/usage.go
+++ b/cmd/ponzu/usage.go
@@ -163,7 +163,7 @@ var usageVersion = `
 `
 
 var usageAdd = `
-[--cli] add, d <addon URI>
+[--cli] add, a <addon URI>
 
 	Downloads addon from specified URI to $GOPATH/src and copys it to the
 	current project's ./addons directory. Must be called from within a 

--- a/cmd/ponzu/usage.go
+++ b/cmd/ponzu/usage.go
@@ -162,6 +162,21 @@ var usageVersion = `
 
 `
 
+var usageAdd = `
+[--cli] add, d <addon URI>
+
+	Downloads addon from specified URI to $GOPATH/src and copys it to the
+	current project's ./addons directory. Must be called from within a 
+	Ponzu project directory.
+
+	Example:
+	$ ponzu add github.com/bosssauce/fbscheduler
+	(or)
+	$ ponzu --cli add github.com/bosssauce/fbscheduler"
+
+
+`
+
 func ponzu(isCLI bool) (map[string]interface{}, error) {
 	kv := make(map[string]interface{})
 

--- a/cmd/ponzu/usage.go
+++ b/cmd/ponzu/usage.go
@@ -171,8 +171,6 @@ var usageAdd = `
 
 	Example:
 	$ ponzu add github.com/bosssauce/fbscheduler
-	(or)
-	$ ponzu --cli add github.com/bosssauce/fbscheduler"
 
 
 `


### PR DESCRIPTION
Reference issue #85. As discussed, this adds a `ponzu add` command to the CLI. It fetches the addon from its URI by wrapping `go get` then copies it to the projects local `./addons` directory. 

There is no switch for automatically installing. Based on the issue discussion that feature needs more thought, so has been omitted.

I've updated the README to include documentation on the command. 

It's been tested as per the approach in the README.