### PR TITLE
Move getGOPATH method to paths.go

### DIFF
--- a/cmd/ponzu/add.go
+++ b/cmd/ponzu/add.go
@@ -6,9 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
-	"runtime"
 	"strings"
 )
 
@@ -58,31 +56,6 @@ func getAddon(args []string) error {
 		return addError(err)
 	}
 	return nil
-}
-
-// resolve GOPATH. In 1.8 can be default, or custom. A custom GOPATH can
-// also contain multiple paths, in which case 'go get' uses the first
-func getGOPATH() (string, error) {
-	var gopath string
-	gopath = os.Getenv("GOPATH")
-	if gopath == "" {
-		// not set, find the default
-		usr, err := user.Current()
-		if err != nil {
-			return gopath, err
-		}
-		gopath = filepath.Join(usr.HomeDir, "go")
-	} else {
-		// parse out in case of multiple, retain first
-		if runtime.GOOS == "windows" {
-			gopaths := strings.Split(gopath, ";")
-			gopath = gopaths[0]
-		} else {
-			gopaths := strings.Split(gopath, ":")
-			gopath = gopaths[0]
-		}
-	}
-	return gopath, nil
 }
 
 // this is distinct from copyAll() in that files are copied, not moved,

--- a/cmd/ponzu/paths.go
+++ b/cmd/ponzu/paths.go
@@ -1,6 +1,12 @@
 package main
 
-import "runtime"
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
 
 // buildOutputName returns the correct ponzu-server file name
 // based on the host Operating System
@@ -10,4 +16,29 @@ func buildOutputName() string {
 	}
 
 	return "ponzu-server"
+}
+
+// resolve GOPATH. In 1.8 can be default, or custom. A custom GOPATH can
+// also contain multiple paths, in which case 'go get' uses the first
+func getGOPATH() (string, error) {
+	var gopath string
+	gopath = os.Getenv("GOPATH")
+	if gopath == "" {
+		// not set, find the default
+		usr, err := user.Current()
+		if err != nil {
+			return gopath, err
+		}
+		gopath = filepath.Join(usr.HomeDir, "go")
+	} else {
+		// parse out in case of multiple, retain first
+		if runtime.GOOS == "windows" {
+			gopaths := strings.Split(gopath, ";")
+			gopath = gopaths[0]
+		} else {
+			gopaths := strings.Split(gopath, ":")
+			gopath = gopaths[0]
+		}
+	}
+	return gopath, nil
 }


### PR DESCRIPTION
It's a 'path' getter and is used in many places of the CLI codebase, should be in paths.go, I think.