### PR TITLE
Allow for external api updates to content items

### DIFF
--- a/system/api/server.go
+++ b/system/api/server.go
@@ -9,4 +9,6 @@ func Run() {
 	http.HandleFunc("/api/content", Record(CORS(Gzip(contentHandler))))
 
 	http.HandleFunc("/api/content/external", Record(CORS(externalContentHandler)))
+
+	http.HandleFunc("/api/content/update", Record(CORS(updateContentHandler)))
 }

--- a/system/api/update.go
+++ b/system/api/update.go
@@ -1,0 +1,222 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ponzu-cms/ponzu/system/admin/upload"
+	"github.com/ponzu-cms/ponzu/system/admin/user"
+	"github.com/ponzu-cms/ponzu/system/db"
+	"github.com/ponzu-cms/ponzu/system/item"
+)
+
+// Updateable accepts or rejects update POST requests to endpoints such as:
+// /api/content/update?type=Review&id=1
+type Updateable interface {
+	// AcceptUpdate allows external content update submissions of a specific type
+	AcceptUpdate(http.ResponseWriter, *http.Request) error
+}
+
+func updateContentHandler(res http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		res.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	err := req.ParseMultipartForm(1024 * 1024 * 4) // maxMemory 4MB
+	if err != nil {
+		log.Println("[Update] error:", err)
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	t := req.URL.Query().Get("type")
+	if t == "" {
+		res.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	p, found := item.Types[t]
+	if !found {
+		log.Println("[Update] attempt to submit unknown type:", t, "from:", req.RemoteAddr)
+		res.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	id := req.URL.Query().Get("id")
+	if id == "" {
+		log.Println("[Update] attempt to submit update with missing id from:", req.RemoteAddr)
+		res.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if user.IsValid(req) == false {
+		res.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	post := p()
+
+	ext, ok := post.(Updateable)
+	if !ok {
+		log.Println("[Update] rejected non-replaceable type:", t, "from:", req.RemoteAddr)
+		res.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	ts := fmt.Sprintf("%d", int64(time.Nanosecond)*time.Now().UnixNano()/int64(time.Millisecond))
+	req.PostForm.Set("timestamp", ts)
+	req.PostForm.Set("updated", ts)
+
+	urlPaths, err := upload.StoreFiles(req)
+	if err != nil {
+		log.Println(err)
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	for name, urlPath := range urlPaths {
+		req.PostForm.Set(name, urlPath)
+	}
+
+	// check for any multi-value fields (ex. checkbox fields)
+	// and correctly format for db storage. Essentially, we need
+	// fieldX.0: value1, fieldX.1: value2 => fieldX: []string{value1, value2}
+	fieldOrderValue := make(map[string]map[string][]string)
+	ordVal := make(map[string][]string)
+	for k, v := range req.PostForm {
+		if strings.Contains(k, ".") {
+			fo := strings.Split(k, ".")
+
+			// put the order and the field value into map
+			field := string(fo[0])
+			order := string(fo[1])
+			fieldOrderValue[field] = ordVal
+
+			// orderValue is 0:[?type=Thing&id=1]
+			orderValue := fieldOrderValue[field]
+			orderValue[order] = v
+			fieldOrderValue[field] = orderValue
+
+			// discard the post form value with name.N
+			req.PostForm.Del(k)
+		}
+
+	}
+
+	// add/set the key & value to the post form in order
+	for f, ov := range fieldOrderValue {
+		for i := 0; i < len(ov); i++ {
+			position := fmt.Sprintf("%d", i)
+			fieldValue := ov[position]
+
+			if req.PostForm.Get(f) == "" {
+				for i, fv := range fieldValue {
+					if i == 0 {
+						req.PostForm.Set(f, fv)
+					} else {
+						req.PostForm.Add(f, fv)
+					}
+				}
+			} else {
+				for _, fv := range fieldValue {
+					req.PostForm.Add(f, fv)
+				}
+			}
+		}
+	}
+
+	hook, ok := post.(item.Hookable)
+	if !ok {
+		log.Println("[Update] error: Type", t, "does not implement item.Hookable or embed item.Item.")
+		res.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	err = hook.BeforeAccept(res, req)
+	if err != nil {
+		log.Println("[Update] error calling BeforeAccept:", err)
+		return
+	}
+
+	err = ext.AcceptUpdate(res, req)
+	if err != nil {
+		log.Println("[Update] error calling Accept:", err)
+		return
+	}
+
+	err = hook.BeforeSave(res, req)
+	if err != nil {
+		log.Println("[Update] error calling BeforeSave:", err)
+		return
+	}
+
+	// set specifier for db bucket in case content is/isn't Trustable
+	var spec string
+
+	_, err = db.SetContent(t+spec+":"+id, req.PostForm)
+	if err != nil {
+		log.Println("[Update] error calling SetContent:", err)
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// set the target in the context so user can get saved value from db in hook
+	ctx := context.WithValue(req.Context(), "target", fmt.Sprintf("%s:%d", t, id))
+	req = req.WithContext(ctx)
+
+	err = hook.AfterSave(res, req)
+	if err != nil {
+		log.Println("[Update] error calling AfterSave:", err)
+		return
+	}
+
+	err = hook.AfterAccept(res, req)
+	if err != nil {
+		log.Println("[Update] error calling AfterAccept:", err)
+		return
+	}
+
+	// create JSON response to send data back to client
+	var data map[string]interface{}
+	if spec != "" {
+		spec = strings.TrimPrefix(spec, "__")
+		data = map[string]interface{}{
+			"status": spec,
+			"type":   t,
+		}
+	} else {
+		spec = "public"
+		data = map[string]interface{}{
+			"id":     id,
+			"status": spec,
+			"type":   t,
+		}
+	}
+
+	resp := map[string]interface{}{
+		"data": []map[string]interface{}{
+			data,
+		},
+	}
+
+	j, err := json.Marshal(resp)
+	if err != nil {
+		log.Println("[Update] error marshalling response to JSON:", err)
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	res.Header().Set("Content-Type", "application/json")
+	_, err = res.Write(j)
+	if err != nil {
+		log.Println("[Update] error writing response:", err)
+		return
+	}
+
+}

--- a/system/api/update.go
+++ b/system/api/update.go
@@ -56,6 +56,7 @@ func updateContentHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	if user.IsValid(req) == false {
+		log.Println("[Update] invalid user.")
 		res.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -64,7 +65,7 @@ func updateContentHandler(res http.ResponseWriter, req *http.Request) {
 
 	ext, ok := post.(Updateable)
 	if !ok {
-		log.Println("[Update] rejected non-replaceable type:", t, "from:", req.RemoteAddr)
+		log.Println("[Update] rejected non-updateable type:", t, "from:", req.RemoteAddr)
 		res.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/system/api/update.go
+++ b/system/api/update.go
@@ -162,7 +162,7 @@ func updateContentHandler(res http.ResponseWriter, req *http.Request) {
 
 	_, err = db.SetContent(t+spec+":"+id, req.PostForm)
 	if err != nil {
-		log.Println("[Update] error calling UpdateContent:", err)
+		log.Println("[Update] error calling SetContent:", err)
 		res.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/system/api/update.go
+++ b/system/api/update.go
@@ -52,8 +52,8 @@ func updateContentHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	id := req.URL.Query().Get("id")
-	if id == "" {
-		log.Println("[Update] attempt to submit update with missing id from:", req.RemoteAddr)
+	if !db.IsValidID(id) {
+		log.Println("[Update] attempt to submit update with missing or invalid id from:", req.RemoteAddr)
 		res.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -160,7 +160,7 @@ func updateContentHandler(res http.ResponseWriter, req *http.Request) {
 	// set specifier for db bucket in case content is/isn't Trustable
 	var spec string
 
-	_, err = db.UpdateContent(t+spec+":"+id, req.PostForm)
+	_, err = db.SetContent(t+spec+":"+id, req.PostForm)
 	if err != nil {
 		log.Println("[Update] error calling UpdateContent:", err)
 		res.WriteHeader(http.StatusInternalServerError)

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -36,6 +36,98 @@ func SetContent(target string, data url.Values) (int, error) {
 	return update(ns, id, data)
 }
 
+// UpdateContent inserts or updates values in the database.
+// Updated content will be merged into existing values from the database.
+// The `target` argument is a string made up of namespace:id (string:int)
+func UpdateContent(target string, data url.Values) (int, error) {
+	t := strings.Split(target, ":")
+	ns, id := t[0], t[1]
+
+	// check if content id == -1 (indicating new post).
+	// if so, run an insert which will assign the next auto incremented int.
+	// this is done because boltdb begins its bucket auto increment value at 0,
+	// which is the zero-value of an int in the Item struct field for ID.
+	// this is a problem when the original first post (with auto ID = 0) gets
+	// overwritten by any new post, originally having no ID, defauting to 0.
+	if id == "-1" {
+		return insert(ns, data)
+	}
+
+	// retrieve existing content from the database
+	existingContent, err := Content(target)
+	if err != nil {
+		return 0, err
+	}
+
+	// Unmarsal the existing values
+	s := item.Types[ns]()
+
+	err = json.Unmarshal(existingContent, &s)
+	if err != nil {
+		log.Println("Error decoding json while sorting", ns, ":", err)
+		return 0, err
+	}
+
+	var specifier string // i.e. __pending, __sorted, etc.
+	if strings.Contains(ns, "__") {
+		spec := strings.Split(ns, "__")
+		ns = spec[0]
+		specifier = "__" + spec[1]
+	}
+
+	cid, err := strconv.Atoi(id)
+	if err != nil {
+		return 0, err
+	}
+
+	// Don't allow the Item fields to be updated from form values
+	data.Del("id")
+	data.Del("uuid")
+	data.Del("slug")
+
+	dec := schema.NewDecoder()
+	dec.SetAliasTag("json")     // allows simpler struct tagging when creating a content type
+	dec.IgnoreUnknownKeys(true) // will skip over form values submitted, but not in struct
+	err = dec.Decode(s, data)
+	if err != nil {
+		return 0, err
+	}
+
+	j, err := json.Marshal(s)
+	if err != nil {
+		return 0, err
+	}
+
+	err = store.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte(ns + specifier))
+		if err != nil {
+			return err
+		}
+
+		err = b.Put([]byte(fmt.Sprintf("%d", cid)), j)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return 0, nil
+	}
+
+	if specifier == "" {
+		go SortContent(ns)
+	}
+
+	// update changes data, so invalidate client caching
+	err = InvalidateCache()
+	if err != nil {
+		return 0, err
+	}
+
+	return cid, nil
+}
+
 func update(ns, id string, data url.Values) (int, error) {
 	var specifier string // i.e. __pending, __sorted, etc.
 	if strings.Contains(ns, "__") {

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -64,7 +64,7 @@ func UpdateContent(target string, data url.Values) (int, error) {
 
 	err = json.Unmarshal(existingContent, &s)
 	if err != nil {
-		log.Println("Error decoding json while sorting", ns, ":", err)
+		log.Println("Error decoding json while updating", ns, ":", err)
 		return 0, err
 	}
 

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -112,8 +112,8 @@ func mergeData(ns string, data url.Values, existingContent []byte) ([]byte, erro
 	var j []byte
 	t, ok := item.Types[ns]
 	if !ok {
+		log.Println("Type not found from namespace:", ns)
 		return j, errors.New("Invalid type.")
-		// handle
 	}
 
 	// Unmarsal the existing values

--- a/system/item/item.go
+++ b/system/item/item.go
@@ -42,6 +42,9 @@ type Sortable interface {
 // to the different lifecycles/events a struct may encounter. Item implements
 // Hookable with no-ops so our user can override only whichever ones necessary.
 type Hookable interface {
+	BeforeAcceptUpdate(http.ResponseWriter, *http.Request) error
+	AfterAcceptUpdate(http.ResponseWriter, *http.Request) error
+
 	BeforeAccept(http.ResponseWriter, *http.Request) error
 	AfterAccept(http.ResponseWriter, *http.Request) error
 
@@ -130,6 +133,16 @@ func (i Item) UniqueID() uuid.UUID {
 // partially implements the Identifiable interface
 func (i Item) String() string {
 	return fmt.Sprintf("Item ID: %s", i.UniqueID())
+}
+
+// BeforeAcceptUpdate is a no-op to ensure structs which embed Item implement Hookable
+func (i Item) BeforeAcceptUpdate(res http.ResponseWriter, req *http.Request) error {
+	return nil
+}
+
+// AfterAcceptUpdate is a no-op to ensure structs which embed Item implement Hookable
+func (i Item) AfterAcceptUpdate(res http.ResponseWriter, req *http.Request) error {
+	return nil
 }
 
 // BeforeAccept is a no-op to ensure structs which embed Item implement Hookable


### PR DESCRIPTION
Allows for external api updates to content items by POST request such as:
/api/content/update?type=Review&id=1

Adds Updateable interface. Implementers are suggested to validate requests inside AcceptUpdate, likely using user.IsValid(req) to validate based on token/secret.  