### PR TITLE
separate UpdateContent and SetContent

### DIFF
--- a/system/api/update.go
+++ b/system/api/update.go
@@ -161,9 +161,9 @@ func updateContentHandler(res http.ResponseWriter, req *http.Request) {
 	// set specifier for db bucket in case content is/isn't Trustable
 	var spec string
 
-	_, err = db.SetContent(t+spec+":"+id, req.PostForm)
+	_, err = db.UpdateContent(t+spec+":"+id, req.PostForm)
 	if err != nil {
-		log.Println("[Update] error calling SetContent:", err)
+		log.Println("[Update] error calling UpdateContent:", err)
 		res.WriteHeader(http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
Provides a clearer way to differentiate when data should be merged or replaced.

Fixes issues where CMS edits for toggling values like Checkbox/Select wouldn't be saved since the value was not sent with the POST. 