### PR TITLE
[cli] add input type specifier to generate content command

### DIFF
--- a/cmd/ponzu/generate.go
+++ b/cmd/ponzu/generate.go
@@ -24,10 +24,6 @@ type generateField struct {
 	View     string
 }
 
-// following the type, an optional third param could designate the editor.Input-like
-// func to call which would output different text based on the element returned
-// blog title:string Author:string PostCategory:string content:string:richtext some_thing:int
-
 // blog title:string Author:string PostCategory:string content:string some_thing:int
 func parseType(args []string) (generateType, error) {
 	t := generateType{

--- a/cmd/ponzu/generate.go
+++ b/cmd/ponzu/generate.go
@@ -156,6 +156,7 @@ func setFieldView(field *generateField, viewType string) error {
 
 	switch strings.ToLower(viewType) {
 	case "hidden":
+		tmpl, err = tmplFrom("gen-hidden.tmpl")
 	case "textarea":
 	case "richtext":
 	case "select":
@@ -165,6 +166,7 @@ func setFieldView(field *generateField, viewType string) error {
 	case "file":
 	case "tags":
 	case "custom":
+		tmpl, err = tmplFrom("gen-custom.tmpl")
 	default:
 		msg := fmt.Sprintf("'%s' is not a recognized view type. Using 'input' instead.")
 		fmt.Println(msg)

--- a/cmd/ponzu/generate.go
+++ b/cmd/ponzu/generate.go
@@ -154,21 +154,28 @@ func setFieldView(field *generateField, viewType string) error {
 		return template.ParseFiles(filepath.Join(tmplDir, filename))
 	}
 
-	switch strings.ToLower(viewType) {
-	case "hidden":
-		tmpl, err = tmplFrom("gen-hidden.tmpl")
-	case "textarea":
-	case "richtext":
-	case "select":
-	case "input":
-		tmpl, err = tmplFrom("gen-input.tmpl")
+	viewType = strings.ToLower(viewType)
+	switch viewType {
 	case "checkbox":
-	case "file":
-	case "tags":
+		tmpl, err = tmplFrom("gen-checkbox.tmpl")
 	case "custom":
 		tmpl, err = tmplFrom("gen-custom.tmpl")
+	case "file":
+		tmpl, err = tmplFrom("gen-file.tmpl")
+	case "hidden":
+		tmpl, err = tmplFrom("gen-hidden.tmpl")
+	case "input", "text":
+		tmpl, err = tmplFrom("gen-input.tmpl")
+	case "richtext":
+		tmpl, err = tmplFrom("gen-richtext.tmpl")
+	case "select":
+		tmpl, err = tmplFrom("gen-select.tmpl")
+	case "textarea":
+		tmpl, err = tmplFrom("gen-textarea.tmpl")
+	case "tags":
+		tmpl, err = tmplFrom("gen-tags.tmpl")
 	default:
-		msg := fmt.Sprintf("'%s' is not a recognized view type. Using 'input' instead.")
+		msg := fmt.Sprintf("'%s' is not a recognized view type. Using 'input' instead.", viewType)
 		fmt.Println(msg)
 		tmpl, err = tmplFrom("gen-input.tmpl")
 	}

--- a/cmd/ponzu/generate.go
+++ b/cmd/ponzu/generate.go
@@ -63,7 +63,7 @@ func parseField(raw string) (generateField, error) {
 
 	field := generateField{
 		Name:     name,
-		Initial:  string(name[0]),
+		Initial:  strings.ToLower(string(name[0])),
 		TypeName: strings.ToLower(data[1]),
 		JSONName: fieldJSONName(data[0]),
 	}

--- a/cmd/ponzu/generate.go
+++ b/cmd/ponzu/generate.go
@@ -37,7 +37,7 @@ func parseType(args []string) (generateType, error) {
 
 	fields := args[1:]
 	for _, field := range fields {
-		f, err := parseField(field)
+		f, err := parseField(field, t)
 		if err != nil {
 			return generateType{}, err
 		}
@@ -52,18 +52,17 @@ func parseType(args []string) (generateType, error) {
 	return t, nil
 }
 
-func parseField(raw string) (generateField, error) {
+func parseField(raw string, gt generateType) (generateField, error) {
 	// contents:string or // contents:string:richtext
 	if !strings.Contains(raw, ":") {
 		return generateField{}, fmt.Errorf("Invalid generate argument. [%s]", raw)
 	}
 
 	data := strings.Split(raw, ":")
-	name := fieldName(data[0])
 
 	field := generateField{
-		Name:     name,
-		Initial:  strings.ToLower(string(name[0])),
+		Name:     fieldName(data[0]),
+		Initial:  gt.Initial,
 		TypeName: strings.ToLower(data[1]),
 		JSONName: fieldJSONName(data[0]),
 	}

--- a/cmd/ponzu/generate.go
+++ b/cmd/ponzu/generate.go
@@ -59,20 +59,23 @@ func parseField(raw string) (generateField, error) {
 	}
 
 	data := strings.Split(raw, ":")
-	view := `nil`
+	name := fieldName(data[0])
 
 	field := generateField{
-		Name:     fieldName(data[0]),
+		Name:     name,
+		Initial:  string(name[0]),
 		TypeName: strings.ToLower(data[1]),
 		JSONName: fieldJSONName(data[0]),
-		View:     view,
 	}
 
+	fieldType := "input"
 	if len(data) == 3 {
-		err := setFieldView(&field, data[2])
-		if err != nil {
-			return generateField{}, err
-		}
+		fieldType = data[2]
+	}
+
+	err := setFieldView(&field, fieldType)
+	if err != nil {
+		return generateField{}, err
 	}
 
 	return field, nil
@@ -153,6 +156,7 @@ func setFieldView(field *generateField, viewType string) error {
 	}
 
 	switch strings.ToLower(viewType) {
+	case "hidden":
 	case "textarea":
 	case "richtext":
 	case "select":
@@ -161,6 +165,7 @@ func setFieldView(field *generateField, viewType string) error {
 	case "checkbox":
 	case "file":
 	case "tags":
+	case "custom":
 	default:
 		tmpl, err = tmplFrom("gen-input.tmpl")
 	}

--- a/cmd/ponzu/generate.go
+++ b/cmd/ponzu/generate.go
@@ -166,6 +166,8 @@ func setFieldView(field *generateField, viewType string) error {
 	case "tags":
 	case "custom":
 	default:
+		msg := fmt.Sprintf("'%s' is not a recognized view type. Using 'input' instead.")
+		fmt.Println(msg)
 		tmpl, err = tmplFrom("gen-input.tmpl")
 	}
 

--- a/cmd/ponzu/templates/gen-checkbox.tmpl
+++ b/cmd/ponzu/templates/gen-checkbox.tmpl
@@ -1,0 +1,5 @@
+View: editor.Checkbox("{{ .Name }}", {{ .Initial }}, map[string]string{
+    "label": "{{ .Name }}",
+}, map[string]string{
+    // "value": "Display Name",    
+}),

--- a/cmd/ponzu/templates/gen-content.tmpl
+++ b/cmd/ponzu/templates/gen-content.tmpl
@@ -20,13 +20,9 @@ func ({{ .Initial }} *{{ .Name }}) MarshalEditor() ([]byte, error) {
 	view, err := editor.Form({{ .Initial }},
         // Take note that the first argument to these Input-like functions 
         // is the string version of each {{ .Name }} field, and must follow 
-        // this pattern for auto-decoding and auto-encoding reasons:{{ $initial := .Initial }}
+        // this pattern for auto-decoding and auto-encoding reasons:
         {{ range .Fields }}editor.Field{
-			View: editor.Input("{{ .Name }}", {{ $initial }}, map[string]string{
-				"label":       "{{ .Name }}",
-				"type":        "text",
-				"placeholder": "Enter the {{ .Name }} here",
-			}),
+			{{ .View }}
 		},
 		{{ end }}
 	)

--- a/cmd/ponzu/templates/gen-custom.tmpl
+++ b/cmd/ponzu/templates/gen-custom.tmpl
@@ -1,0 +1,6 @@
+View: []byte(`
+    <div class="input-field col s12">
+        <label class="active">{{ .Name }}</label>
+        <!-- Add your custom editor field view here. -->
+    </div>
+`),

--- a/cmd/ponzu/templates/gen-custom.tmpl
+++ b/cmd/ponzu/templates/gen-custom.tmpl
@@ -3,4 +3,4 @@ View: []byte(`
                 <label class="active">{{ .Name }}</label>
                 <!-- Add your custom editor field view here. -->
             </div>
-`),
+            `),

--- a/cmd/ponzu/templates/gen-custom.tmpl
+++ b/cmd/ponzu/templates/gen-custom.tmpl
@@ -1,6 +1,6 @@
 View: []byte(`
-    <div class="input-field col s12">
-        <label class="active">{{ .Name }}</label>
-        <!-- Add your custom editor field view here. -->
-    </div>
+            <div class="input-field col s12">
+                <label class="active">{{ .Name }}</label>
+                <!-- Add your custom editor field view here. -->
+            </div>
 `),

--- a/cmd/ponzu/templates/gen-file.tmpl
+++ b/cmd/ponzu/templates/gen-file.tmpl
@@ -1,0 +1,4 @@
+View: editor.File("{{ .Name }}", {{ .Initial }}, map[string]string{
+    "label":       "{{ .Name }}",
+    "placeholder": "Upload the {{ .Name }} here",
+}),

--- a/cmd/ponzu/templates/gen-hidden.tmpl
+++ b/cmd/ponzu/templates/gen-hidden.tmpl
@@ -1,0 +1,3 @@
+View: editor.Input("{{ .Name }}", {{ .Initial }}, map[string]string{
+    "type":        "hidden",
+}),

--- a/cmd/ponzu/templates/gen-input.tmpl
+++ b/cmd/ponzu/templates/gen-input.tmpl
@@ -1,0 +1,5 @@
+View: editor.Input("{{ .Name }}", {{ .Initial }}, map[string]string{
+    "label":       "{{ .Name }}",
+    "type":        "text",
+    "placeholder": "Enter the {{ .Name }} here",
+}),

--- a/cmd/ponzu/templates/gen-richtext.tmpl
+++ b/cmd/ponzu/templates/gen-richtext.tmpl
@@ -1,0 +1,4 @@
+View: editor.Richtext("{{ .Name }}", {{ .Initial }}, map[string]string{
+    "label":       "{{ .Name }}",
+    "placeholder": "Enter the {{ .Name }} here",
+}),

--- a/cmd/ponzu/templates/gen-select.tmpl
+++ b/cmd/ponzu/templates/gen-select.tmpl
@@ -1,0 +1,5 @@
+View: editor.Select("{{ .Name }}", {{ .Initial }}, map[string]string{
+    "label": "{{ .Name }}",
+}, map[string]string{
+    // "value": "Display Name",    
+}),

--- a/cmd/ponzu/templates/gen-tags.tmpl
+++ b/cmd/ponzu/templates/gen-tags.tmpl
@@ -1,0 +1,4 @@
+View: editor.Tags("{{ .Name }}", {{ .Initial }}, map[string]string{
+    "label":       "{{ .Name }}",
+    "placeholder": "+{{ .Name }}",
+}),

--- a/cmd/ponzu/templates/gen-textarea.tmpl
+++ b/cmd/ponzu/templates/gen-textarea.tmpl
@@ -1,0 +1,4 @@
+View: editor.Textarea("{{ .Name }}", {{ .Initial }}, map[string]string{
+    "label":       "{{ .Name }}",
+    "placeholder": "Enter the {{ .Name }} here",
+}),


### PR DESCRIPTION
As referenced in the [community suggestion project](https://github.com/ponzu-cms/ponzu/projects/2#card-1540549), this PR adds the ability to define which type of HTML input to show in an editor view for a content type in the CMS. 

The specifier is entirely optional, and if not added the behavior is exactly the same as prior versions. To use, add a third parameter to the generated field, like so:

```bash
$ ponzu gen c song title:string artist:string:input description:string:richtext genre:string:select
```

In the `content/song.go` file generated, the fields' views will automatically be the following:
Title: Input
Artist: Input
Description: Richtext
Genre: Select

This saves time in the set-up phase for your content types and should also be helpful if you're looking for documentation on how to use each editor input func from the `editor` package. The following input view types are implemented:


| CLI parameter | Generates |
|---------------|-----------| 
| checkbox | `editor.Checkbox()` |
| custom | generates a pre-styled empty div to fill with HTML |
| file | `editor.File()` |
| hidden | `editor.Input()` + uses type=hidden |
| input, text | `editor.Input()` |
| richtext | `editor.Richtext()` |
| select | `editor.Select()` |
| textarea | `editor.Textarea()` |
| tags | `editor.Tags()` |