### PR TITLE
[core] better sort ordering and more reliable content API results

### DIFF
--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -39,7 +39,10 @@ const managerHTML = `
 						hour = hour + 12;
 					}
 
-				var date = new Date(year, month, day, hour, minute);
+				// add seconds to Date() to differentiate times more precisely,
+				// although not 100% accurately
+				var sec = (new Date()).getSeconds();
+				var date = new Date(year, month, day, hour, minute, sec);
 				
 				$ts.val(date.getTime());
 			}

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -941,8 +941,13 @@ func contentsHandler(res http.ResponseWriter, req *http.Request) {
 										var path = window.location.pathname;
 										var s = sort.val();
 										var t = getParam('type');
+										var status = getParam('status');
 
-										window.location.replace(path + '?type=' + t + '&order=' + s)
+										if (status == "") {
+											status = "public";
+										}
+
+										window.location.replace(path + '?type=' + t + '&order=' + s + '&status=' + status);
 									});
 
 									var order = getParam('order');

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -1531,7 +1531,7 @@ func editHandler(res http.ResponseWriter, req *http.Request) {
 
 		// create a timestamp if one was not set
 		if ts == "" {
-			ts = fmt.Sprintf("%d", int64(time.Nanosecond)*time.Now().UnixNano()/int64(time.Millisecond))
+			ts = fmt.Sprintf("%d", int64(time.Nanosecond)*time.Now().UTC().UnixNano()/int64(time.Millisecond))
 			req.PostForm.Set("timestamp", ts)
 		}
 

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -570,9 +570,9 @@ func SortContent(namespace string) {
 			return err
 		}
 
-		// encode to json and store as 'i:post.Time()':post
+		// encode to json and store as 'post.Time():i':post
 		for i := range bb {
-			cid := fmt.Sprintf("%d", posts[i].Time())
+			cid := fmt.Sprintf("%d:%d", posts[i].Time(), i)
 			err = b.Put([]byte(cid), bb[i])
 			if err != nil {
 				return err

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -572,7 +572,7 @@ func SortContent(namespace string) {
 
 		// encode to json and store as 'i:post.Time()':post
 		for i := range bb {
-			cid := fmt.Sprintf("%d:%d", i, posts[i].Time())
+			cid := fmt.Sprintf("%d", posts[i].Time())
 			err = b.Put([]byte(cid), bb[i])
 			if err != nil {
 				return err


### PR DESCRIPTION
After using Ponzu in high-traffic a production environment for a few months, I noticed some of the content results were out of order :-1:  (both from the API and in the admin dashboard). With this PR, the sorted content buckets use a slightly different key identifier to avoid the natural order Bolt will store data in a bucket.

If you already have a lot of data in your CMS, just go through each content type and save one of the items -- this will trigger a re-sort and fix any out of order content.

Additionally,  the timestamps generated by Ponzu (rather than the dashboard editor) are now in UTC. This should make it easier to eventually deal with data moved from server to server.