### PR TITLE
[core] Configurable full-text search with Bleve + search API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ $ ponzu --dev -fork=github.com/nilslice/ponzu new /path/to/new/project
 - [golang.org/x/text/transform](https://golang.org/x/text/transform)
 - [golang.org/x/crypto/bcrypt](https://golang.org/x/crypto/bcrypt)
 - [golang.org/x/net/http2](https://golang.org/x/net/http2)
+- [github.com/blevesearch/bleve](https://github.com/blevesearch/bleve)
 - [github.com/nilslice/jwt](https://github.com/nilslice/jwt)
 - [github.com/nilslice/email](https://github.com/nilslice/email)
 - [github.com/gorilla/schema](https://github.com/gorilla/schema)

--- a/system/api/search.go
+++ b/system/api/search.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/url"
+
+	"github.com/ponzu-cms/ponzu/system/db"
+	"github.com/ponzu-cms/ponzu/system/item"
+)
+
+func searchContentHandler(res http.ResponseWriter, req *http.Request) {
+	qs := req.URL.Query()
+	t := qs.Get("type")
+	// type must be set, future version may compile multi-type result set
+	if t == "" {
+		res.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	it, ok := item.Types[t]
+	if !ok {
+		res.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if hide(it(), res, req) {
+		return
+	}
+
+	q, err := url.QueryUnescape(qs.Get("q"))
+	if err != nil {
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// q must be set
+	if q == "" {
+		res.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// execute search for query provided, if no index for type send 404
+	matches, err := db.SearchType(t, q)
+	if err == db.ErrNoSearchIndex {
+		res.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if err != nil {
+		log.Println("[search] Error:", err)
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// respond with json formatted results
+	bb, err := db.ContentMulti(matches)
+	if err != nil {
+		log.Println("[search] Error:", err)
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	var result = []json.RawMessage{}
+	for i := range bb {
+		result = append(result, bb[i])
+	}
+
+	j, err := fmtJSON(result...)
+	if err != nil {
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	j, err = omit(it(), j)
+	if err != nil {
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	sendData(res, req, j)
+}

--- a/system/api/search.go
+++ b/system/api/search.go
@@ -44,7 +44,7 @@ func searchContentHandler(res http.ResponseWriter, req *http.Request) {
 	// execute search for query provided, if no index for type send 404
 	matches, err := db.SearchType(t, q)
 	if err == db.ErrNoSearchIndex {
-		res.WriteHeader(http.StatusBadRequest)
+		res.WriteHeader(http.StatusNotFound)
 		return
 	}
 	if err != nil {

--- a/system/api/search.go
+++ b/system/api/search.go
@@ -61,6 +61,11 @@ func searchContentHandler(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// if we have matches, push the first as its matched by relevance
+	if len(bb) > 0 {
+		push(res, req, it, bb[0])
+	}
+
 	var result = []json.RawMessage{}
 	for i := range bb {
 		result = append(result, bb[i])

--- a/system/api/server.go
+++ b/system/api/server.go
@@ -13,4 +13,6 @@ func Run() {
 	http.HandleFunc("/api/content/update", Record(CORS(updateContentHandler)))
 
 	http.HandleFunc("/api/content/delete", Record(CORS(deleteContentHandler)))
+
+	http.HandleFunc("/api/search", Record(CORS(searchContentHandler)))
 }

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -123,7 +123,7 @@ func update(ns, id string, data url.Values, existingContent *[]byte) (int, error
 
 	// add data to search index
 	target := fmt.Sprintf("%s:%s", ns, id)
-	err = Search[ns].Index(target, j)
+	err = Search[ns].Index(target, string(j))
 	if err != nil {
 		return 0, err
 	}
@@ -249,7 +249,7 @@ func insert(ns string, data url.Values) (int, error) {
 
 	// add data to search index
 	target := fmt.Sprintf("%s:%s", ns, cid)
-	err = Search[ns].Index(target, j)
+	err = Search[ns].Index(target, string(j))
 	if err != nil {
 		return 0, err
 	}

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -10,9 +10,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ponzu-cms/ponzu/system/item"
+
 	"github.com/boltdb/bolt"
 	"github.com/gorilla/schema"
-	"github.com/ponzu-cms/ponzu/system/item"
 	uuid "github.com/satori/go.uuid"
 )
 

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -124,7 +124,7 @@ func update(ns, id string, data url.Values, existingContent *[]byte) (int, error
 	go func() {
 		// update data in search index
 		target := fmt.Sprintf("%s:%s", ns, id)
-		err = UpdateSearchIndex(target, string(j))
+		err = UpdateSearchIndex(target, j)
 		if err != nil {
 			log.Println("[search] UpdateSearchIndex Error:", err)
 		}
@@ -252,7 +252,7 @@ func insert(ns string, data url.Values) (int, error) {
 	go func() {
 		// add data to seach index
 		target := fmt.Sprintf("%s:%s", ns, cid)
-		err = UpdateSearchIndex(target, string(j))
+		err = UpdateSearchIndex(target, j)
 		if err != nil {
 			log.Println("[search] UpdateSearchIndex Error:", err)
 		}

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -121,9 +121,8 @@ func update(ns, id string, data url.Values, existingContent *[]byte) (int, error
 		return 0, err
 	}
 
-	// add data to search index
 	target := fmt.Sprintf("%s:%s", ns, id)
-	err = Search[ns].Index(target, string(j))
+	err = UpdateSearchIndex(target, string(j))
 	if err != nil {
 		return 0, err
 	}
@@ -135,7 +134,7 @@ func mergeData(ns string, data url.Values, existingContent []byte) ([]byte, erro
 	var j []byte
 	t, ok := item.Types[ns]
 	if !ok {
-		return nil, fmt.Errorf("namespace type not found:", ns)
+		return nil, fmt.Errorf("Namespace type not found: %s", ns)
 	}
 
 	// Unmarsal the existing values
@@ -247,9 +246,8 @@ func insert(ns string, data url.Values) (int, error) {
 		return 0, err
 	}
 
-	// add data to search index
 	target := fmt.Sprintf("%s:%s", ns, cid)
-	err = Search[ns].Index(target, string(j))
+	err = UpdateSearchIndex(target, string(j))
 	if err != nil {
 		return 0, err
 	}
@@ -311,6 +309,15 @@ func DeleteContent(target string) error {
 	err = InvalidateCache()
 	if err != nil {
 		return err
+	}
+
+	// delete indexed data from search index
+	if !strings.Contains(ns, "__") {
+		target = fmt.Sprintf("%s:%s", ns, id)
+		err = DeleteSearchIndex(target)
+		if err != nil {
+			return err
+		}
 	}
 
 	// exception to typical "run in goroutine" pattern:

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -82,7 +82,7 @@ func Init() {
 		for t := range item.Types {
 			err := MapSearchIndex(t)
 			if err != nil {
-				log.Fatalln("[search] Error:", err)
+				log.Fatalln(err)
 				return
 			}
 

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -80,7 +80,7 @@ func Init() {
 
 	go func() {
 		for t := range item.Types {
-			err := MapIndex(t)
+			err := MapSearchIndex(t)
 			if err != nil {
 				log.Fatalln("[search] Error:", err)
 				return

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -80,6 +80,12 @@ func Init() {
 
 	go func() {
 		for t := range item.Types {
+			err := MapIndex(t)
+			if err != nil {
+				log.Fatalln("[search] Error:", err)
+				return
+			}
+
 			SortContent(t)
 		}
 	}()

--- a/system/db/search.go
+++ b/system/db/search.go
@@ -1,0 +1,46 @@
+package db
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/blevesearch/bleve"
+)
+
+// Search tracks all search indices to use throughout system
+var Search map[string]bleve.Index
+
+func init() {
+	Search = make(map[string]bleve.Index)
+}
+
+// MapIndex creates the mapping for a type and tracks the index to be used within
+// the system for adding/deleting/checking data
+func MapIndex(typeName string) error {
+	mapping := bleve.NewIndexMapping()
+	mapping.StoreDynamic = false
+	idxFile := typeName + ".index"
+	var idx bleve.Index
+
+	// check if index exists, use it or create new one
+	pwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	if _, err = os.Stat(filepath.Join(pwd, idxFile)); os.IsNotExist(err) {
+		idx, err = bleve.New(idxFile, mapping)
+		if err != nil {
+			return err
+		}
+	} else {
+		idx, err = bleve.Open(idxFile)
+		if err != nil {
+			return err
+		}
+	}
+
+	// add the type name to the index and track the index
+	Search[typeName] = idx
+
+	return nil
+}

--- a/system/db/search.go
+++ b/system/db/search.go
@@ -53,9 +53,6 @@ func MapSearchIndex(typeName string) error {
 	}
 
 	mapping, err := s.SearchMapping()
-	if err == item.ErrNoSearchMapping {
-		return nil
-	}
 	if err != nil {
 		return err
 	}

--- a/system/db/search.go
+++ b/system/db/search.go
@@ -7,9 +7,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ponzu-cms/ponzu/system/item"
+
 	"github.com/blevesearch/bleve"
 	"github.com/blevesearch/bleve/mapping"
-	"github.com/ponzu-cms/ponzu/system/item"
 )
 
 var (

--- a/system/db/search.go
+++ b/system/db/search.go
@@ -28,7 +28,7 @@ func MapIndex(typeName string) error {
 
 	mapping := bleve.NewIndexMapping()
 	mapping.StoreDynamic = false
-	idxPath := typeName + ".index"
+	idxName := typeName + ".index"
 	var idx bleve.Index
 
 	// check if index exists, use it or create new one
@@ -44,7 +44,8 @@ func MapIndex(typeName string) error {
 		return err
 	}
 
-	if _, err = os.Stat(filepath.Join(searchPath, idxPath)); os.IsNotExist(err) {
+	idxPath := filepath.Join(searchPath, idxName)
+	if _, err = os.Stat(idxPath); os.IsNotExist(err) {
 		idx, err = bleve.New(idxPath, mapping)
 		if err != nil {
 			return err

--- a/system/db/search.go
+++ b/system/db/search.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/ponzu-cms/ponzu/system/item"
 
+	"encoding/json"
+
 	"github.com/blevesearch/bleve"
 	"github.com/blevesearch/bleve/mapping"
 )
@@ -24,6 +26,7 @@ var (
 // Searchable ...
 type Searchable interface {
 	SearchMapping() (*mapping.IndexMappingImpl, error)
+	IndexContent() bool
 }
 
 func init() {
@@ -42,6 +45,11 @@ func MapSearchIndex(typeName string) error {
 	s, ok := it().(Searchable)
 	if !ok {
 		return fmt.Errorf("[search] MapSearchIndex Error: Item type %s doesn't implement db.Searchable", typeName)
+	}
+
+	// skip setting or using index for types that shouldn't be indexed
+	if !s.IndexContent() {
+		return nil
 	}
 
 	mapping, err := s.SearchMapping()
@@ -97,8 +105,20 @@ func UpdateSearchIndex(id string, data interface{}) error {
 
 	idx, ok := Search[ns]
 	if ok {
+		// unmarshal json to struct, error if not registered
+		it, ok := item.Types[ns]
+		if !ok {
+			return fmt.Errorf("[search] UpdateSearchIndex Error: type '%s' doesn't exist", ns)
+		}
+
+		p := it()
+		err := json.Unmarshal(data.([]byte), &p)
+		if err != nil {
+			return err
+		}
+
 		// add data to search index
-		return idx.Index(id, data)
+		return idx.Index(id, p)
 	}
 
 	return nil

--- a/system/item/item.go
+++ b/system/item/item.go
@@ -212,11 +212,11 @@ func (i Item) AfterReject(res http.ResponseWriter, req *http.Request) error {
 
 // SearchMapping returns a default implementation of a Bleve IndexMappingImpl
 // partially implements db.Searchable
-func (i Item) SearchMapping() *mapping.IndexMappingImpl {
+func (i Item) SearchMapping() (*mapping.IndexMappingImpl, error) {
 	mapping := bleve.NewIndexMapping()
 	mapping.StoreDynamic = false
 
-	return mapping
+	return mapping, nil
 }
 
 // Slug returns a URL friendly string from the title of a post item

--- a/system/item/item.go
+++ b/system/item/item.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/blevesearch/bleve"
+	"github.com/blevesearch/bleve/mapping"
 	uuid "github.com/satori/go.uuid"
 	"golang.org/x/text/transform"
 	"golang.org/x/text/unicode/norm"
@@ -206,6 +208,15 @@ func (i Item) BeforeReject(res http.ResponseWriter, req *http.Request) error {
 // AfterReject is a no-op to ensure structs which embed Item implement Hookable
 func (i Item) AfterReject(res http.ResponseWriter, req *http.Request) error {
 	return nil
+}
+
+// SearchMapping returns a default implementation of a Bleve IndexMappingImpl
+// partially implements db.Searchable
+func SearchMapping() *mapping.IndexMappingImpl {
+	mapping := bleve.NewIndexMapping()
+	mapping.StoreDynamic = false
+
+	return mapping
 }
 
 // Slug returns a URL friendly string from the title of a post item

--- a/system/item/item.go
+++ b/system/item/item.go
@@ -219,6 +219,12 @@ func (i Item) SearchMapping() (*mapping.IndexMappingImpl, error) {
 	return mapping, nil
 }
 
+// IndexContent determines if a type should be indexed for searching
+// partially implements db.Searchable
+func (i Item) IndexContent() bool {
+	return false
+}
+
 // Slug returns a URL friendly string from the title of a post item
 func Slug(i Identifiable) (string, error) {
 	// get the name of the post item

--- a/system/item/item.go
+++ b/system/item/item.go
@@ -212,7 +212,7 @@ func (i Item) AfterReject(res http.ResponseWriter, req *http.Request) error {
 
 // SearchMapping returns a default implementation of a Bleve IndexMappingImpl
 // partially implements db.Searchable
-func SearchMapping() *mapping.IndexMappingImpl {
+func (i Item) SearchMapping() *mapping.IndexMappingImpl {
 	mapping := bleve.NewIndexMapping()
 	mapping.StoreDynamic = false
 

--- a/system/item/types.go
+++ b/system/item/types.go
@@ -26,6 +26,9 @@ var (
 	// if requested by a valid admin or user
 	ErrAllowHiddenItem = errors.New(`Allow hidden item`)
 
+	// ErrNoSearchMapping can be used to tell the system not to create an index mapping
+	ErrNoSearchMapping = errors.New(`No search mapping for item`)
+
 	// Types is a map used to reference a type name to its actual Editable type
 	// mainly for lookups in /admin route based utilities
 	Types map[string]func() interface{}

--- a/system/item/types.go
+++ b/system/item/types.go
@@ -26,9 +26,6 @@ var (
 	// if requested by a valid admin or user
 	ErrAllowHiddenItem = errors.New(`Allow hidden item`)
 
-	// ErrNoSearchMapping can be used to tell the system not to create an index mapping
-	ErrNoSearchMapping = errors.New(`No search mapping for item`)
-
 	// Types is a map used to reference a type name to its actual Editable type
 	// mainly for lookups in /admin route based utilities
 	Types map[string]func() interface{}


### PR DESCRIPTION
This PR adds the ability to enable indexing content on a per-type basis, to be searched through the new `/api/search?type=<Type>&q=<Query String>` endpoint, as partially detailed in #51.

A new interface in the `system/db` package, called `Searchable` contains two methods: `IndexContent() bool` and `SearchMapping() (*mapping.IndexMapping, error)`. `SearchMapping` has a default implementation on `item.Item` to set up the default index mapping from Bleve. In order to tell Ponzu to manage your content in Bleve's index, all you need to do is implement the `IndexContent` and return `true` from the method. 

The search endpoint can take any [query format supported by Bleve](http://www.blevesearch.com/docs/Query-String-Query/), as long as your underlying data types meet the requirements (dates for date range queries, numeric types for numeric range queries, etc). Also, the search endpoint will respect the various interfaces used by content types to hide or omit content from API results. `item.Hideable` and `item.Omittable` are both applied to the search endpoint. `item.Pushable` is applied only to the first matched result. 