### PR TITLE
[core] Add cancellation context to system backups

### DIFF
--- a/cmd/ponzu/generate.go
+++ b/cmd/ponzu/generate.go
@@ -24,7 +24,7 @@ type generateField struct {
 	View     string
 }
 
-var reservedFiledNames = map[string]string{
+var reservedFieledNames = map[string]string{
 	"uuid":      "UUID",
 	"item":      "Item",
 	"id":        "ID",
@@ -36,7 +36,7 @@ var reservedFiledNames = map[string]string{
 func legalFieldNames(fields ...generateField) (bool, map[string]string) {
 	conflicts := make(map[string]string)
 	for _, field := range fields {
-		for jsonName, fieldName := range reservedFiledNames {
+		for jsonName, fieldName := range reservedFieledNames {
 			if field.JSONName == jsonName || field.Name == fieldName {
 				conflicts[jsonName] = fieldName
 			}

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -195,9 +195,12 @@ func configHandler(res http.ResponseWriter, req *http.Request) {
 }
 
 func backupHandler(res http.ResponseWriter, req *http.Request) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	switch req.URL.Query().Get("source") {
 	case "system":
-		err := db.Backup(res)
+		err := db.Backup(ctx, res)
 		if err != nil {
 			log.Println("Failed to run backup on system:", err)
 			res.WriteHeader(http.StatusInternalServerError)
@@ -205,7 +208,7 @@ func backupHandler(res http.ResponseWriter, req *http.Request) {
 		}
 
 	case "analytics":
-		err := analytics.Backup(res)
+		err := analytics.Backup(ctx, res)
 		if err != nil {
 			log.Println("Failed to run backup on analytics:", err)
 			res.WriteHeader(http.StatusInternalServerError)
@@ -213,7 +216,7 @@ func backupHandler(res http.ResponseWriter, req *http.Request) {
 		}
 
 	case "uploads":
-		err := upload.Backup(res)
+		err := upload.Backup(ctx, res)
 		if err != nil {
 			log.Println("Failed to run backup on uploads:", err)
 			res.WriteHeader(http.StatusInternalServerError)

--- a/system/db/backup.go
+++ b/system/db/backup.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -8,19 +9,29 @@ import (
 	"github.com/boltdb/bolt"
 )
 
-// Backup writes a snapshot of the system.db database to an HTTP response
-func Backup(res http.ResponseWriter) error {
-	err := store.View(func(tx *bolt.Tx) error {
-		ts := time.Now().Unix()
-		disposition := `attachment; filename="system-%d.db.bak"`
+// Backup writes a snapshot of the system.db database to an HTTP response. The
+// output is discarded if we get a cancellation signal.
+func Backup(ctx context.Context, res http.ResponseWriter) error {
+	errChan := make(chan error, 1)
 
-		res.Header().Set("Content-Type", "application/octet-stream")
-		res.Header().Set("Content-Disposition", fmt.Sprintf(disposition, ts))
-		res.Header().Set("Content-Length", fmt.Sprintf("%d", int(tx.Size())))
+	go func() {
+		errChan <- store.View(func(tx *bolt.Tx) error {
+			ts := time.Now().Unix()
+			disposition := `attachment; filename="system-%d.db.bak"`
 
-		_, err := tx.WriteTo(res)
+			res.Header().Set("Content-Type", "application/octet-stream")
+			res.Header().Set("Content-Disposition", fmt.Sprintf(disposition, ts))
+			res.Header().Set("Content-Length", fmt.Sprintf("%d", int(tx.Size())))
+
+			_, err := tx.WriteTo(res)
+			return err
+		})
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-errChan:
 		return err
-	})
-
-	return err
+	}
 }


### PR DESCRIPTION
Shout-out to @eticzon for closing out #110 - which handles failed or cancelled backup requests super nicely. Now, dropped requests or errors somewhere in the processing will stop processing the backup and save resources.  Thank you, @eticzon!