### PR TITLE
[core] more Admin and new Addon lifecycle hooks

### DIFF
--- a/system/addon/addon.go
+++ b/system/addon/addon.go
@@ -237,3 +237,9 @@ func reverseDNS(meta Meta) (string, error) {
 
 	return strings.Join(append(strap, name), "."), nil
 }
+
+// String returns the addon name and overrides the item String() method in
+// item.Identifiable interface
+func (a *Addon) String() string {
+	return a.PonzuAddonName
+}

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -1913,6 +1913,20 @@ func editHandler(res http.ResponseWriter, req *http.Request) {
 			return
 		}
 
+		if cid == "-1" {
+			err = hook.BeforeAdminCreate(res, req)
+			if err != nil {
+				log.Println("Error running BeforeAdminCreate method in editHandler for:", t, err)
+				return
+			}
+		} else {
+			err = hook.BeforeAdminUpdate(res, req)
+			if err != nil {
+				log.Println("Error running BeforeAdminUpdate method in editHandler for:", t, err)
+				return
+			}
+		}
+
 		err = hook.BeforeSave(res, req)
 		if err != nil {
 			log.Println("Error running BeforeSave method in editHandler for:", t, err)
@@ -1940,6 +1954,20 @@ func editHandler(res http.ResponseWriter, req *http.Request) {
 		if err != nil {
 			log.Println("Error running AfterSave method in editHandler for:", t, err)
 			return
+		}
+
+		if cid == "-1" {
+			err = hook.AfterAdminCreate(res, req)
+			if err != nil {
+				log.Println("Error running AfterAdminUpdate method in editHandler for:", t, err)
+				return
+			}
+		} else {
+			err = hook.AfterAdminUpdate(res, req)
+			if err != nil {
+				log.Println("Error running AfterAdminUpdate method in editHandler for:", t, err)
+				return
+			}
 		}
 
 		scheme := req.URL.Scheme
@@ -2029,6 +2057,12 @@ func deleteHandler(res http.ResponseWriter, req *http.Request) {
 		}
 	}
 
+	err = hook.BeforeAdminDelete(res, req)
+	if err != nil {
+		log.Println("Error running BeforeAdminDelete method in deleteHandler for:", t, err)
+		return
+	}
+
 	err = hook.BeforeDelete(res, req)
 	if err != nil {
 		log.Println("Error running BeforeDelete method in deleteHandler for:", t, err)
@@ -2043,6 +2077,12 @@ func deleteHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	err = hook.AfterDelete(res, req)
+	if err != nil {
+		log.Println("Error running AfterDelete method in deleteHandler for:", t, err)
+		return
+	}
+
+	err = hook.AfterAdminDelete(res, req)
 	if err != nil {
 		log.Println("Error running AfterDelete method in deleteHandler for:", t, err)
 		return

--- a/system/item/item.go
+++ b/system/item/item.go
@@ -56,6 +56,15 @@ type Hookable interface {
 	BeforeAPIDelete(http.ResponseWriter, *http.Request) error
 	AfterAPIDelete(http.ResponseWriter, *http.Request) error
 
+	BeforeAdminCreate(http.ResponseWriter, *http.Request) error
+	AfterAdminCreate(http.ResponseWriter, *http.Request) error
+
+	BeforeAdminUpdate(http.ResponseWriter, *http.Request) error
+	AfterAdminUpdate(http.ResponseWriter, *http.Request) error
+
+	BeforeAdminDelete(http.ResponseWriter, *http.Request) error
+	AfterAdminDelete(http.ResponseWriter, *http.Request) error
+
 	BeforeSave(http.ResponseWriter, *http.Request) error
 	AfterSave(http.ResponseWriter, *http.Request) error
 
@@ -180,6 +189,36 @@ func (i Item) AfterAPIDelete(res http.ResponseWriter, req *http.Request) error {
 	return nil
 }
 
+// BeforeAdminCreate is a no-op to ensure structs which embed Item implement Hookable
+func (i Item) BeforeAdminCreate(res http.ResponseWriter, req *http.Request) error {
+	return nil
+}
+
+// AfterAdminCreate is a no-op to ensure structs which embed Item implement Hookable
+func (i Item) AfterAdminCreate(res http.ResponseWriter, req *http.Request) error {
+	return nil
+}
+
+// BeforeAdminUpdate is a no-op to ensure structs which embed Item implement Hookable
+func (i Item) BeforeAdminUpdate(res http.ResponseWriter, req *http.Request) error {
+	return nil
+}
+
+// AfterAdminUpdate is a no-op to ensure structs which embed Item implement Hookable
+func (i Item) AfterAdminUpdate(res http.ResponseWriter, req *http.Request) error {
+	return nil
+}
+
+// BeforeAdminDelete is a no-op to ensure structs which embed Item implement Hookable
+func (i Item) BeforeAdminDelete(res http.ResponseWriter, req *http.Request) error {
+	return nil
+}
+
+// AfterAdminDelete is a no-op to ensure structs which embed Item implement Hookable
+func (i Item) AfterAdminDelete(res http.ResponseWriter, req *http.Request) error {
+	return nil
+}
+
 // BeforeSave is a no-op to ensure structs which embed Item implement Hookable
 func (i Item) BeforeSave(res http.ResponseWriter, req *http.Request) error {
 	return nil
@@ -217,6 +256,26 @@ func (i Item) BeforeReject(res http.ResponseWriter, req *http.Request) error {
 
 // AfterReject is a no-op to ensure structs which embed Item implement Hookable
 func (i Item) AfterReject(res http.ResponseWriter, req *http.Request) error {
+	return nil
+}
+
+// BeforeEnable is a no-op to ensure structs which embed Item implement Hookable
+func (i Item) BeforeEnable(res http.ResponseWriter, req *http.Request) error {
+	return nil
+}
+
+// AfterEnable is a no-op to ensure structs which embed Item implement Hookable
+func (i Item) AfterEnable(res http.ResponseWriter, req *http.Request) error {
+	return nil
+}
+
+// BeforeDisable is a no-op to ensure structs which embed Item implement Hookable
+func (i Item) BeforeDisable(res http.ResponseWriter, req *http.Request) error {
+	return nil
+}
+
+// AfterDisable is a no-op to ensure structs which embed Item implement Hookable
+func (i Item) AfterDisable(res http.ResponseWriter, req *http.Request) error {
 	return nil
 }
 

--- a/system/item/item.go
+++ b/system/item/item.go
@@ -67,6 +67,13 @@ type Hookable interface {
 
 	BeforeReject(http.ResponseWriter, *http.Request) error
 	AfterReject(http.ResponseWriter, *http.Request) error
+
+	// Enable/Disable used for addons
+	BeforeEnable(http.ResponseWriter, *http.Request) error
+	AfterEnable(http.ResponseWriter, *http.Request) error
+
+	BeforeDisable(http.ResponseWriter, *http.Request) error
+	AfterDisable(http.ResponseWriter, *http.Request) error
 }
 
 // Hideable lets a user keep items hidden


### PR DESCRIPTION
This PR adds new methods to the `item.Hookable` interface which enable Addons to intercept the point in time at which they are Enabled/Disabled as well adding more fine-grain control to the Admin actions on content, including Creating, Updating and Deleting. The method set for `item.Hookable` is a bit large, but as long as the content types embed `item.Item`, as expected, all these methods in the interface are implemented by default. No additional work is needed, but you now have more options to override and customize your system.