### PR TITLE
[cli] adding reference type and auto-repeater generate syntax

### DIFF
--- a/cmd/ponzu/templates/gen-content.tmpl
+++ b/cmd/ponzu/templates/gen-content.tmpl
@@ -2,7 +2,9 @@ package content
 
 import (
 	"fmt"
-
+	{{ if .HasReferences }}
+	"github.com/bosssauce/reference"
+	{{ end }}
 	"github.com/ponzu-cms/ponzu/management/editor"
 	"github.com/ponzu-cms/ponzu/system/item"
 )

--- a/cmd/ponzu/templates/gen-file-repeater.tmpl
+++ b/cmd/ponzu/templates/gen-file-repeater.tmpl
@@ -1,0 +1,4 @@
+View: editor.FileRepeater("{{ .Name }}", {{ .Initial }}, map[string]string{
+    "label":       "{{ .Name }}",
+    "placeholder": "Upload the {{ .Name }} here",
+}),

--- a/cmd/ponzu/templates/gen-input-repeater.tmpl
+++ b/cmd/ponzu/templates/gen-input-repeater.tmpl
@@ -1,0 +1,5 @@
+View: editor.InputRepeater("{{ .Name }}", {{ .Initial }}, map[string]string{
+    "label":       "{{ .Name }}",
+    "type":        "text",
+    "placeholder": "Enter the {{ .Name }} here",
+}),

--- a/cmd/ponzu/templates/gen-reference-repeater.tmpl
+++ b/cmd/ponzu/templates/gen-reference-repeater.tmpl
@@ -1,0 +1,6 @@
+View: reference.SelectRepeater("[[ .Name ]]", [[ .Initial ]], map[string]string{
+        "label": "[[ .Name ]]",
+    }, 
+    "[[ .ReferenceName ]]", 
+    `[[ range .ReferenceJSONTags ]]{{ .[[ . ]] }} [[ else ]][[ .ReferenceName ]]: {{ .id }}[[ end ]]`,
+),

--- a/cmd/ponzu/templates/gen-reference.tmpl
+++ b/cmd/ponzu/templates/gen-reference.tmpl
@@ -1,0 +1,6 @@
+View: reference.Select("[[ .Name ]]", [[ .Initial ]], map[string]string{
+        "label": "[[ .Name ]]",
+    }, 
+    "[[ .ReferenceName ]]", 
+    `[[ range .ReferenceJSONTags ]]{{ .[[ . ]] }} [[ else ]][[ .ReferenceName ]]: {{ .id }}[[ end ]]`,
+),

--- a/cmd/ponzu/templates/gen-select-repeater.tmpl
+++ b/cmd/ponzu/templates/gen-select-repeater.tmpl
@@ -1,0 +1,5 @@
+View: editor.SelectRepeater("{{ .Name }}", {{ .Initial }}, map[string]string{
+    "label": "{{ .Name }}",
+}, map[string]string{
+    // "value": "Display Name",    
+}),


### PR DESCRIPTION
This PR contains some updates to the CLI a bit to add the ability to generate references to other content types.. here's the syntax:
```bash
$ ponzu gen c author name:string bio:string:textarea city:string year_joined:int
$ ponzu gen c article title:string author:@author,name,city content:string:richtext photos:"[]string":file
```

The trailing `,name,city` suffix to `author:@author` set the displayed option names in the select dropdown inside the CMS. If you leave them blank, it defaults to `Author: {{ .id }}`

Additionally, any `[]T` slice type i.e. `photos:"[]string":file` in the example above, will automatically generate a `editor.FileRepeater`, or the "Repeater" for the view specifier (as long as one exists).

Currently, there are "Repeaters" for `file`, `select`, and `input` which will each have their Repeater generated automatically when accompanied by a `[]T` type

For example:
`$ ponzu gen c gallery images:"[]string":file` => `editor.FileRepeater()` 
`$ ponzu gen c gallery images:"string":file` => `editor.File()` 


*Side Note:* you never specify the view type (file, select, richtext etc) for a reference, i.e. `@author`.. it will always be a `reference.Select` or `reference.SelectRepeater` if you pass `[]@author`