### PR TITLE
[core] add CSVFormattable interface to export CSV formatted content

### DIFF
--- a/management/format/csv.go
+++ b/management/format/csv.go
@@ -1,0 +1,9 @@
+// Package format provides interfaces to format content into various kinds of
+// data
+package format
+
+// CSVFormattable is implemented with the method FormatCSV, which must return the ordered
+// slice of JSON struct tag names for the type implmenting it
+type CSVFormattable interface {
+	FormatCSV() []string
+}

--- a/system/admin/export.go
+++ b/system/admin/export.go
@@ -1,0 +1,133 @@
+package admin
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"encoding/csv"
+
+	"io/ioutil"
+	"os"
+
+	"github.com/ponzu-cms/ponzu/management/format"
+	"github.com/ponzu-cms/ponzu/system/db"
+	"github.com/ponzu-cms/ponzu/system/item"
+	"github.com/tidwall/gjson"
+)
+
+func exportHandler(res http.ResponseWriter, req *http.Request) {
+	// /admin/contents/export?type=Blogpost&format=csv
+	q := req.URL.Query()
+	t := q.Get("type")
+	f := strings.ToLower(q.Get("format"))
+
+	if t == "" || f == "" {
+		v, err := Error400()
+		if err != nil {
+			res.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		res.WriteHeader(http.StatusBadRequest)
+		_, err = res.Write(v)
+		if err != nil {
+			res.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+	}
+
+	pt, ok := item.Types[t]
+	if !ok {
+		res.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	switch f {
+	case "csv":
+		csv, ok := pt().(format.CSVFormattable)
+		if !ok {
+			res.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		fields := csv.FormatCSV()
+		exportCSV(res, req, pt, fields)
+
+	default:
+		res.WriteHeader(http.StatusBadRequest)
+		return
+	}
+}
+
+func exportCSV(res http.ResponseWriter, req *http.Request, pt func() interface{}, fields []string) {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "exportcsv-")
+	if err != nil {
+		log.Println("Failed to create tmp file for CSV export:", err)
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	defer os.Remove(filepath.Join(os.TempDir(), tmpFile.Name()))
+	defer tmpFile.Close()
+
+	csvBuf := csv.NewWriter(tmpFile)
+
+	t := req.URL.Query().Get("type")
+
+	// get content data and loop through creating a csv row per result
+	bb := db.ContentAll(t)
+
+	err = csvBuf.Write(fields)
+	if err != nil {
+		res.WriteHeader(http.StatusInternalServerError)
+		log.Println("Failed to write column headers:", fields)
+		return
+	}
+
+	for row := range bb {
+		// unmarshal data and loop over fields
+		rowBuf := []string{}
+
+		for _, col := range fields {
+			// pull out each field as the column value
+			result := gjson.GetBytes(bb[row], col)
+
+			// append it to the buffer
+			rowBuf = append(rowBuf, result.String())
+		}
+
+		// write row to csv
+		err := csvBuf.Write(rowBuf)
+		if err != nil {
+			res.WriteHeader(http.StatusInternalServerError)
+			log.Println("Failed to write column headers:", fields)
+			return
+		}
+	}
+
+	// write the buffer to a content-disposition response
+	csvB, err := ioutil.ReadAll(tmpFile)
+	if err != nil {
+		log.Println("Failed to read tmp file for CSV export:", err)
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	ts := time.Now().Unix()
+	disposition := `attachment; filename="export-%s-%d.csv"`
+
+	res.Header().Set("Content-Type", "text/csv")
+	res.Header().Set("Content-Disposition", fmt.Sprintf(disposition, t, ts))
+	res.Header().Set("Content-Length", fmt.Sprintf("%d", len(csvB)))
+
+	_, err = res.Write(csvB)
+	if err != nil {
+		log.Println("Failed to write tmp file to response for CSV export:", err)
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+}

--- a/system/admin/export.go
+++ b/system/admin/export.go
@@ -70,6 +70,11 @@ func exportCSV(res http.ResponseWriter, req *http.Request, pt func() interface{}
 		return
 	}
 
+	err = os.Chmod(tmpFile.Name(), 0666)
+	if err != nil {
+		log.Println("chmod err:", err)
+	}
+
 	csvBuf := csv.NewWriter(tmpFile)
 
 	t := req.URL.Query().Get("type")

--- a/system/admin/export.go
+++ b/system/admin/export.go
@@ -1,21 +1,20 @@
 package admin
 
 import (
+	"encoding/csv"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
-	"encoding/csv"
-
-	"io/ioutil"
-	"os"
-
 	"github.com/ponzu-cms/ponzu/management/format"
 	"github.com/ponzu-cms/ponzu/system/db"
 	"github.com/ponzu-cms/ponzu/system/item"
+
 	"github.com/tidwall/gjson"
 )
 
@@ -108,6 +107,8 @@ func exportCSV(res http.ResponseWriter, req *http.Request, pt func() interface{}
 			return
 		}
 	}
+
+	csvBuf.Flush()
 
 	// write the buffer to a content-disposition response
 	csvB, err := ioutil.ReadAll(tmpFile)

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -1502,7 +1502,7 @@ func contentsHandler(res http.ResponseWriter, req *http.Request) {
 		btn += `<br/>
 				<a href="/admin/contents/export?type=` + t + `&format=csv" class="green darken-4 btn export-post waves-effect waves-light">
 					<i class="material-icons left">system_update_alt</i>
-					.CSV
+					CSV
 				</a>`
 	}
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -2530,7 +2530,7 @@ func searchHandler(res http.ResponseWriter, req *http.Request) {
 		btn = `<br/>
 				<a href="/admin/contents/export?type=` + t + `&format=csv" class="green darken-4 btn export-post waves-effect waves-light">
 					<i class="material-icons left">system_update_alt</i>
-					.CSV
+					CSV
 				</a>`
 		html = html + b.String() + btn
 	}

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -1497,18 +1497,16 @@ func contentsHandler(res http.ResponseWriter, req *http.Request) {
 		<a href="/admin/edit?type=` + t + `" class="btn new-post waves-effect waves-light">
 			New ` + t + `
 		</a>`
-	html = html + b.String() + btn
 
 	if _, ok := pt.(format.CSVFormattable); ok {
-		btn = `<br/>
+		btn += `<br/>
 				<a href="/admin/contents/export?type=` + t + `&format=csv" class="green darken-4 btn export-post waves-effect waves-light">
 					<i class="material-icons left">system_update_alt</i>
 					.CSV
 				</a>`
-		html = html + b.String() + btn
 	}
 
-	html += `</div></div>` + script
+	html += b.String() + script + btn + `</div></div>`
 
 	adminView, err := Admin([]byte(html))
 	if err != nil {

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -1496,21 +1496,19 @@ func contentsHandler(res http.ResponseWriter, req *http.Request) {
 	btn := `<div class="col s3">
 		<a href="/admin/edit?type=` + t + `" class="btn new-post waves-effect waves-light">
 			New ` + t + `
-		</a>
-		</div>`
+		</a>`
 	html = html + b.String() + btn
 
 	if _, ok := pt.(format.CSVFormattable); ok {
-		btn = `<div class="col s3">
-				<a href="/admin/edit/export?type=` + t + `&format=csv" class="green darken-4 btn export-post waves-effect waves-light">
+		btn = `<br/>
+				<a href="/admin/contents/export?type=` + t + `&format=csv" class="green darken-4 btn export-post waves-effect waves-light">
 					<i class="material-icons left">system_update_alt</i>
 					.CSV
-				</a>
-				</div>`
+				</a>`
 		html = html + b.String() + btn
 	}
 
-	html += `</div>` + script
+	html += `</div></div>` + script
 
 	adminView, err := Admin([]byte(html))
 	if err != nil {
@@ -2527,21 +2525,19 @@ func searchHandler(res http.ResponseWriter, req *http.Request) {
 	btn := `<div class="col s3">
 			<a href="/admin/edit?type=` + t + `" class="btn new-post waves-effect waves-light">
 				New ` + t + `
-			</a>
-			</div>`
+			</a>`
 	html = html + b.String() + btn
 
 	if _, ok := post.(format.CSVFormattable); ok {
-		btn = `<div class="col s3">
-				<a href="/admin/edit/export?type=` + t + `&format=csv" class="green darken-4 btn export-post waves-effect waves-light">
+		btn = `<br/>
+				<a href="/admin/contents/export?type=` + t + `&format=csv" class="green darken-4 btn export-post waves-effect waves-light">
 					<i class="material-icons left">system_update_alt</i>
 					.CSV
-				</a>
-				</div>`
+				</a>`
 		html = html + b.String() + btn
 	}
 
-	html += `</div>`
+	html += `</div></div>`
 
 	adminView, err := Admin([]byte(html))
 	if err != nil {

--- a/system/admin/server.go
+++ b/system/admin/server.go
@@ -37,6 +37,7 @@ func Run() {
 
 	http.HandleFunc("/admin/contents", user.Auth(contentsHandler))
 	http.HandleFunc("/admin/contents/search", user.Auth(searchHandler))
+	http.HandleFunc("/admin/contents/export", user.Auth(exportHandler))
 
 	http.HandleFunc("/admin/edit", user.Auth(editHandler))
 	http.HandleFunc("/admin/edit/delete", user.Auth(deleteHandler))

--- a/system/admin/static/dashboard/css/admin.css
+++ b/system/admin/static/dashboard/css/admin.css
@@ -81,7 +81,7 @@ li a:hover {
     transition: color 0.3s ease;
 }
 
-a.new-post {
+a.new-post, a.export-post {
     margin: 0.5rem 0 1rem 0.75rem;
 }
 


### PR DESCRIPTION
This PR adds the ability to trigger a download of the content per type in CSV format from within the admin dashboard. In order to add the CSV download button to the CMS, you need to implement the management/format package's `format.CSVFormattable` interface with its single method, `FormatCSV() []string`:

```go
func (b *Book) FormatCSV() []string {
        return []string{
                "id",
                "timestamp",
                "title",
                "other_json_struct_tags",
        }
}
```

Just like other Ponzu content extension interfaces, like `Push()`, you will return the JSON struct tags for the fields you want exported to the CSV file. These will also be the "header" row in the CSV file to give titles to the file columns. Keep in mind that all of `item.Item`'s fields are available here as well.