### PR TITLE
make a proper item for Hookable methods

### DIFF
--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -2078,6 +2078,17 @@ func deleteHandler(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	data, err := db.Content(t + ":" + id)
+	if err != nil {
+		log.Println("Error in db.Content ", t+":"+id, err)
+		return
+	}
+
+	err = json.Unmarshal(data, post)
+	if err != nil {
+		log.Println("Error unmarshalling ", t, "=", id, err, " Hooks will be called on a zero-value.")
+	}
+
 	reject := req.URL.Query().Get("reject")
 	if reject == "true" {
 		err = hook.BeforeReject(res, req)

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -1926,6 +1926,23 @@ func editHandler(res http.ResponseWriter, req *http.Request) {
 			return
 		}
 
+		// Let's be nice and make a proper item for the Hookable methods
+		dec := schema.NewDecoder()
+		dec.IgnoreUnknownKeys(true)
+		dec.SetAliasTag("json")
+		err = dec.Decode(post, req.PostForm)
+		if err != nil {
+			log.Println("Error decoding post form for edit handler:", t, err)
+			res.WriteHeader(http.StatusBadRequest)
+			errView, err := Error400()
+			if err != nil {
+				return
+			}
+
+			res.Write(errView)
+			return
+		}
+
 		if cid == "-1" {
 			err = hook.BeforeAdminCreate(res, req)
 			if err != nil {

--- a/system/api/create.go
+++ b/system/api/create.go
@@ -12,6 +12,8 @@ import (
 	"github.com/ponzu-cms/ponzu/system/admin/upload"
 	"github.com/ponzu-cms/ponzu/system/db"
 	"github.com/ponzu-cms/ponzu/system/item"
+
+	"github.com/gorilla/schema"
 )
 
 // Createable accepts or rejects external POST requests to endpoints such as:
@@ -127,6 +129,17 @@ func createContentHandler(res http.ResponseWriter, req *http.Request) {
 	hook, ok := post.(item.Hookable)
 	if !ok {
 		log.Println("[Create] error: Type", t, "does not implement item.Hookable or embed item.Item.")
+		res.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// Let's be nice and make a proper item for the Hookable methods
+	dec := schema.NewDecoder()
+	dec.IgnoreUnknownKeys(true)
+	dec.SetAliasTag("json")
+	err = dec.Decode(post, req.PostForm)
+	if err != nil {
+		log.Println("Error decoding post form for edit handler:", t, err)
 		res.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/system/api/delete.go
+++ b/system/api/delete.go
@@ -65,6 +65,18 @@ func deleteContentHandler(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	data, err := db.Content(t + ":" + id)
+	if err != nil {
+		log.Println("Error in db.Content ", t+":"+id, err)
+		res.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	err = json.Unmarshal(data, post)
+	if err != nil {
+		log.Println("Error unmarshalling ", t, "=", id, err, " Hooks will be called on a zero-value.")
+	}
+
 	err = hook.BeforeAPIDelete(res, req)
 	if err != nil {
 		log.Println("[Delete] error calling BeforeAPIDelete:", err)


### PR DESCRIPTION
We have all of the information, it's nice to be access the item's members in a natural way, without having to look at the request.

This was already done for the approveContentHandler, but here I added to the editHandler of admin, and the createHandler of the API.