### PR TITLE
db.init cleanup

### DIFF
--- a/system/db/init.go
+++ b/system/db/init.go
@@ -84,23 +84,11 @@ func Init() {
 	if err != nil {
 		log.Fatalln("Failed to invalidate cache.", err)
 	}
-
-	go func() {
-		for t := range item.Types {
-			err := search.MapIndex(t)
-			if err != nil {
-				log.Fatalln(err)
-				return
-			}
-
-			SortContent(t)
-		}
-	}()
 }
 
 // InitSearchIndex initializes Search Index for search to be functional
 // This was moved out of db.Init and put to main(), because addon checker was initializing db together with
-// search indexing initialisation in time when there were no item.Types defined so search index was always 
+// search indexing initialisation in time when there were no item.Types defined so search index was always
 // empty when using addons. We still have no guarentee whatsoever that item.Types is defined
 // Should be called from a goroutine after SetContent is successful (SortContent requirement)
 func InitSearchIndex() {


### PR DESCRIPTION
Removing old ``InitSearchIndex``code from `db.Init`, so we do not have two Indexer Init calls.
Sorry, this got lost in last repeated PR.