### PR TITLE
[core] fix HTML escaping for select tag options in reference package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+ponzu-server
+uploads
+search
+*.db

--- a/addons/github.com/bosssauce/reference/reference.go
+++ b/addons/github.com/bosssauce/reference/reference.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"html"
 	"html/template"
 	"log"
 	"strings"
@@ -143,7 +144,7 @@ func encodeDataToOptions(contentType, tmplString string) (map[string]string, err
 				contentType, err.Error())
 		}
 
-		options[k] = v.String()
+		options[k] = html.UnescapeString(v.String())
 	}
 
 	return options, nil


### PR DESCRIPTION
Fixes HTML characters in reference options which were not being unescaped after the JSON decoding, making them display incorrectly in the admin UI.  

Also adds `.gitignore` file with commonly checked in Ponzu files/directories that shouldn't be in version control.