### PR TITLE
[core] add default domain name to init form based on client hostname

### DIFF
--- a/system/admin/admin.go
+++ b/system/admin/admin.go
@@ -160,10 +160,23 @@ var initAdminHTML = `
         
         var logo = $('a.brand-logo');
         var name = $('input#name');
+        var domain = $('input#domain');
+        var hostname = domain.val();
 
+        if (hostname === '') {    
+            hostname = window.location.host || window.location.hostname;
+        }
+        
+        if (hostname.indexOf(':') !== -1) {
+            hostname = hostname.split(':')[0];
+        }
+        
+        domain.val(hostname);
+        
         name.on('change', function(e) {
             logo.text(e.target.value);
         });
+
     });
 </script>
 `


### PR DESCRIPTION
There have been several issues filed where errors are reported during JSON decoding of references. 99% of them are solved by using the correct domain / hostname during development. This PR adds a suggested hostname during initialization (`/admin/init`) which looks at the client's `window.location.host||hostname` property and uses it, without the port number.