### PR TITLE
[core] adding String method to generated content type with better default

### DIFF
--- a/cmd/ponzu/templates/gen-content.tmpl
+++ b/cmd/ponzu/templates/gen-content.tmpl
@@ -39,3 +39,9 @@ func ({{ .Initial }} *{{ .Name }}) MarshalEditor() ([]byte, error) {
 func init() {
 	item.Types["{{ .Name }}"] = func() interface{} { return new({{ .Name }}) }
 }
+
+// String defines how a {{ .Name }} is printed. Update it using more descriptive
+// fields from the {{ .Name }} struct type
+func ({{ .Initial }} *{{ .Name }}) String() string {
+	return fmt.Sprintf("{{ .Name }}: %s", {{ .Initial }}.UUID)
+}


### PR DESCRIPTION
By adding the String method to a content type generated by the CLI, it makes for easier and more obvious feature discovery so user's know to change the display of their items in the CMS UI. 

Credit to @jasonkeene for the suggestion at Boulder Gopher's meetup.