### PR TITLE
Upgrade from ponzu-dev or fork

### DIFF
--- a/cmd/ponzu/upgrade.go
+++ b/cmd/ponzu/upgrade.go
@@ -122,6 +122,14 @@ func upgradePonzuProjectDir(path string) error {
 		}
 	}
 
+	// development upgrade?
+	if dev {
+		if fork != "" {
+			fmt.Println("Upgrading from " + fork)
+		} else {
+			fmt.Println("Upgrading from 'ponzu-dev' branch")
+		}
+	}
 	err = createProjectInDir(path)
 	if err != nil {
 		fmt.Println("")
@@ -167,5 +175,7 @@ func upgradePonzuProjectDir(path string) error {
 }
 
 func init() {
+	upgradeCmd.Flags().StringVar(&fork, "fork", "", "modify repo source for Ponzu core development")
+	upgradeCmd.Flags().BoolVar(&dev, "dev", false, "modify environment for Ponzu core development")
 	RegisterCmdlineCommand(upgradeCmd)
 }


### PR DESCRIPTION
Allow `upgrade` command to pass `--dev` and `--fork` flags to reclone from development branches to make development & testing easier