### PR TITLE
Follow symlinks when archiving

### DIFF
--- a/system/admin/upload/backup.go
+++ b/system/admin/upload/backup.go
@@ -27,6 +27,9 @@ func Backup(ctx context.Context, res http.ResponseWriter) error {
 	}
 
 	err = backup.ArchiveFS(ctx, "uploads", f)
+	if err != nil {
+		return err
+	}
 
 	err = f.Close()
 	if err != nil {

--- a/system/search/backup.go
+++ b/system/search/backup.go
@@ -26,7 +26,10 @@ func Backup(ctx context.Context, res http.ResponseWriter) error {
 		return err
 	}
 
-	backup.ArchiveFS(ctx, "search", f)
+	err = backup.ArchiveFS(ctx, "search", f)
+	if err != nil {
+		return err
+	}
 
 	err = f.Close()
 	if err != nil {


### PR DESCRIPTION
fixes #288 

* ArchiveFS will now follow the symlink if base dir is one.

The lack of proper error bubbling had caused me a bit of a headache, so:
* ArchiveFS errors will now be bubbled properly.
