### PR TITLE
Adds BeforeAPIResponse and AfterAPIResponse hooks 

### DIFF
--- a/docs/src/Interfaces/Item.md
+++ b/docs/src/Interfaces/Item.md
@@ -115,7 +115,7 @@ Approve, Reject routines, and API response routines. All methods in its set take
 ```go
 type Hookable interface {
     BeforeAPIResponse(http.ResponseWriter, *http.Request, []byte) ([]byte, error)
-	AfterAPIResponse(http.ResponseWriter, *http.Request, []byte) error
+    AfterAPIResponse(http.ResponseWriter, *http.Request, []byte) error
 
     BeforeAPICreate(http.ResponseWriter, *http.Request) error
     AfterAPICreate(http.ResponseWriter, *http.Request) error

--- a/docs/src/Interfaces/Item.md
+++ b/docs/src/Interfaces/Item.md
@@ -107,13 +107,16 @@ func (p *Post) Omit(res http.ResponseWriter, req *http.Request) ([]string, error
 
 ### [item.Hookable](https://godoc.org/github.com/ponzu-cms/ponzu/system/item#Hookable)
 Hookable provides lifecycle hooks into the http handlers which manage Save, Delete,
-Approve, and Reject routines. All methods in its set take an 
-`http.ResponseWriter, *http.Request` and return an `error`.
+Approve, Reject routines, and API response routines. All methods in its set take an 
+`http.ResponseWriter, *http.Request` and return an `error`. Hooks which relate to the API response, additionally take data of type `[]byte`, and may provide a return of the same type.
 
 ##### Method Set
 
 ```go
 type Hookable interface {
+    BeforeAPIResponse(http.ResponseWriter, *http.Request, []byte) ([]byte, error)
+	AfterAPIResponse(http.ResponseWriter, *http.Request, []byte) error
+
     BeforeAPICreate(http.ResponseWriter, *http.Request) error
     AfterAPICreate(http.ResponseWriter, *http.Request) error
 
@@ -154,6 +157,28 @@ type Hookable interface {
 ```
 
 ##### Implementations
+
+#### BeforeAPIResponse
+BeforeAPIResponse is called before content is sent over the Ponzu API, and 
+provides an opportunity to modify the response data. If a non-nil `error` value
+is returned, a 500 Internal Server Error is sent instead of the response.
+
+```go
+func (p *Post) BeforeAPIResponse(res http.ResponseWriter, req *http.Request, data []byte) ([]byte, error) {
+    return data, nil
+}
+```
+
+#### AfterAPIResponse
+AfterAPIResponse is called after content is sent over the Ponzu API, whether
+modified or not. The sent response data is available to the hook. A non-nil 
+`error` return will simply generate a log message.
+
+```go
+func (p *Post) AfterAPIResponse(res http.ResponseWriter, req *http.Request, data []byte) error {
+    return nil
+}
+```
 
 #### BeforeAPICreate
 BeforeAPICreate is called before an item is created via a 3rd-party client. If a 

--- a/system/api/handlers.go
+++ b/system/api/handlers.go
@@ -100,7 +100,31 @@ func contentsHandler(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// assert hookable
+	get := it()
+	hook, ok := get.(item.Hookable)
+	if !ok {
+		log.Println("[Response] error: Type", t, "does not implement item.Hookable or embed item.Item.")
+		res.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// hook before response
+	err = hook.BeforeAPIResponse(res, req)
+	if err != nil {
+		log.Println("[Response] error calling BeforeAPIResponse:", err)
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
 	sendData(res, req, j)
+
+	// hook after response
+	err = hook.AfterAPIResponse(res, req)
+	if err != nil {
+		log.Println("[Response] error calling AfterAPIResponse:", err)
+		return
+	}
 }
 
 func contentHandler(res http.ResponseWriter, req *http.Request) {
@@ -156,7 +180,31 @@ func contentHandler(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// assert hookable
+	get := p
+	hook, ok := get.(item.Hookable)
+	if !ok {
+		log.Println("[Response] error: Type", t, "does not implement item.Hookable or embed item.Item.")
+		res.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// hook before response
+	err = hook.BeforeAPIResponse(res, req)
+	if err != nil {
+		log.Println("[Response] error calling BeforeAPIResponse:", err)
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
 	sendData(res, req, j)
+
+	// hook after response
+	err = hook.AfterAPIResponse(res, req)
+	if err != nil {
+		log.Println("[Response] error calling AfterAPIResponse:", err)
+		return
+	}
 }
 
 func contentHandlerBySlug(res http.ResponseWriter, req *http.Request) {
@@ -206,7 +254,32 @@ func contentHandlerBySlug(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// assert hookable
+	get := p
+	hook, ok := get.(item.Hookable)
+	if !ok {
+		log.Println("[Response] error: Type", t, "does not implement item.Hookable or embed item.Item.")
+		res.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// hook before response
+	err = hook.BeforeAPIResponse(res, req)
+	if err != nil {
+		log.Println("[Response] error calling BeforeAPIResponse:", err)
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
 	sendData(res, req, j)
+
+	// hook after response
+	err = hook.AfterAPIResponse(res, req)
+	if err != nil {
+		log.Println("[Response] error calling AfterAPIResponse:", err)
+		return
+	}
+
 }
 
 func uploadsHandler(res http.ResponseWriter, req *http.Request) {

--- a/system/api/handlers.go
+++ b/system/api/handlers.go
@@ -110,7 +110,7 @@ func contentsHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	// hook before response
-	err = hook.BeforeAPIResponse(res, req)
+	j, err = hook.BeforeAPIResponse(res, req, j)
 	if err != nil {
 		log.Println("[Response] error calling BeforeAPIResponse:", err)
 		res.WriteHeader(http.StatusInternalServerError)
@@ -120,7 +120,7 @@ func contentsHandler(res http.ResponseWriter, req *http.Request) {
 	sendData(res, req, j)
 
 	// hook after response
-	err = hook.AfterAPIResponse(res, req)
+	_, err = hook.AfterAPIResponse(res, req, j)
 	if err != nil {
 		log.Println("[Response] error calling AfterAPIResponse:", err)
 		return
@@ -190,7 +190,7 @@ func contentHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	// hook before response
-	err = hook.BeforeAPIResponse(res, req)
+	j, err = hook.BeforeAPIResponse(res, req, j)
 	if err != nil {
 		log.Println("[Response] error calling BeforeAPIResponse:", err)
 		res.WriteHeader(http.StatusInternalServerError)
@@ -200,7 +200,7 @@ func contentHandler(res http.ResponseWriter, req *http.Request) {
 	sendData(res, req, j)
 
 	// hook after response
-	err = hook.AfterAPIResponse(res, req)
+	_, err = hook.AfterAPIResponse(res, req, j)
 	if err != nil {
 		log.Println("[Response] error calling AfterAPIResponse:", err)
 		return
@@ -264,7 +264,7 @@ func contentHandlerBySlug(res http.ResponseWriter, req *http.Request) {
 	}
 
 	// hook before response
-	err = hook.BeforeAPIResponse(res, req)
+	j, err = hook.BeforeAPIResponse(res, req, j)
 	if err != nil {
 		log.Println("[Response] error calling BeforeAPIResponse:", err)
 		res.WriteHeader(http.StatusInternalServerError)
@@ -274,7 +274,7 @@ func contentHandlerBySlug(res http.ResponseWriter, req *http.Request) {
 	sendData(res, req, j)
 
 	// hook after response
-	err = hook.AfterAPIResponse(res, req)
+	_, err = hook.AfterAPIResponse(res, req, j)
 	if err != nil {
 		log.Println("[Response] error calling AfterAPIResponse:", err)
 		return

--- a/system/api/handlers.go
+++ b/system/api/handlers.go
@@ -120,7 +120,7 @@ func contentsHandler(res http.ResponseWriter, req *http.Request) {
 	sendData(res, req, j)
 
 	// hook after response
-	_, err = hook.AfterAPIResponse(res, req, j)
+	err = hook.AfterAPIResponse(res, req, j)
 	if err != nil {
 		log.Println("[Response] error calling AfterAPIResponse:", err)
 		return
@@ -200,7 +200,7 @@ func contentHandler(res http.ResponseWriter, req *http.Request) {
 	sendData(res, req, j)
 
 	// hook after response
-	_, err = hook.AfterAPIResponse(res, req, j)
+	err = hook.AfterAPIResponse(res, req, j)
 	if err != nil {
 		log.Println("[Response] error calling AfterAPIResponse:", err)
 		return
@@ -274,7 +274,7 @@ func contentHandlerBySlug(res http.ResponseWriter, req *http.Request) {
 	sendData(res, req, j)
 
 	// hook after response
-	_, err = hook.AfterAPIResponse(res, req, j)
+	err = hook.AfterAPIResponse(res, req, j)
 	if err != nil {
 		log.Println("[Response] error calling AfterAPIResponse:", err)
 		return

--- a/system/item/item.go
+++ b/system/item/item.go
@@ -24,13 +24,13 @@ func init() {
 	// We store the compiled regex as the key
 	// and assign the replacement as the map's value.
 	rxList = map[*regexp.Regexp][]byte{
-		regexp.MustCompile("`[-]+`"):                  []byte("-"),
-		regexp.MustCompile("[[:space:]]"):             []byte("-"),
-		regexp.MustCompile("[[:blank:]]"):             []byte(""),
-		regexp.MustCompile("`[^a-z0-9]`i"):            []byte("-"),
-		regexp.MustCompile("[!/:-@[-`{-~]"):           []byte(""),
-		regexp.MustCompile("/[^\x20-\x7F]/"):          []byte(""),
-		regexp.MustCompile("`&(amp;)?#?[a-z0-9]+;`i"): []byte("-"),
+		regexp.MustCompile("`[-]+`"):                                                                         []byte("-"),
+		regexp.MustCompile("[[:space:]]"):                                                                    []byte("-"),
+		regexp.MustCompile("[[:blank:]]"):                                                                    []byte(""),
+		regexp.MustCompile("`[^a-z0-9]`i"):                                                                   []byte("-"),
+		regexp.MustCompile("[!/:-@[-`{-~]"):                                                                  []byte(""),
+		regexp.MustCompile("/[^\x20-\x7F]/"):                                                                 []byte(""),
+		regexp.MustCompile("`&(amp;)?#?[a-z0-9]+;`i"):                                                        []byte("-"),
 		regexp.MustCompile("`&([a-z])(acute|uml|circ|grave|ring|cedil|slash|tilde|caron|lig|quot|rsquo);`i"): []byte("\\1"),
 	}
 }
@@ -65,6 +65,9 @@ type Sortable interface {
 // to the different lifecycles/events a struct may encounter. Item implements
 // Hookable with no-ops so our user can override only whichever ones necessary.
 type Hookable interface {
+	BeforeAPIResponse(http.ResponseWriter, *http.Request) error
+	AfterAPIResponse(http.ResponseWriter, *http.Request) error
+
 	BeforeAPICreate(http.ResponseWriter, *http.Request) error
 	AfterAPICreate(http.ResponseWriter, *http.Request) error
 
@@ -175,6 +178,16 @@ func (i Item) UniqueID() uuid.UUID {
 // partially implements the Identifiable interface
 func (i Item) String() string {
 	return fmt.Sprintf("Item ID: %s", i.UniqueID())
+}
+
+// BeforeAPIResponse is a no-op to ensure structs which embed Item implement Hookable
+func (i Item) BeforeAPIResponse(res http.ResponseWriter, req *http.Request) error {
+	return nil
+}
+
+// AfterAPIResponse is a no-op to ensure structs which embed Item implement Hookable
+func (i Item) AfterAPIResponse(res http.ResponseWriter, req *http.Request) error {
+	return nil
 }
 
 // BeforeAPICreate is a no-op to ensure structs which embed Item implement Hookable

--- a/system/item/item.go
+++ b/system/item/item.go
@@ -66,7 +66,7 @@ type Sortable interface {
 // Hookable with no-ops so our user can override only whichever ones necessary.
 type Hookable interface {
 	BeforeAPIResponse(http.ResponseWriter, *http.Request, []byte) ([]byte, error)
-	AfterAPIResponse(http.ResponseWriter, *http.Request, []byte) ([]byte, error)
+	AfterAPIResponse(http.ResponseWriter, *http.Request, []byte) error
 
 	BeforeAPICreate(http.ResponseWriter, *http.Request) error
 	AfterAPICreate(http.ResponseWriter, *http.Request) error
@@ -186,8 +186,8 @@ func (i Item) BeforeAPIResponse(res http.ResponseWriter, req *http.Request, data
 }
 
 // AfterAPIResponse is a no-op to ensure structs which embed Item implement Hookable
-func (i Item) AfterAPIResponse(res http.ResponseWriter, req *http.Request, data []byte) ([]byte, error) {
-	return data, nil
+func (i Item) AfterAPIResponse(res http.ResponseWriter, req *http.Request, data []byte) error {
+	return nil
 }
 
 // BeforeAPICreate is a no-op to ensure structs which embed Item implement Hookable

--- a/system/item/item.go
+++ b/system/item/item.go
@@ -65,8 +65,8 @@ type Sortable interface {
 // to the different lifecycles/events a struct may encounter. Item implements
 // Hookable with no-ops so our user can override only whichever ones necessary.
 type Hookable interface {
-	BeforeAPIResponse(http.ResponseWriter, *http.Request) error
-	AfterAPIResponse(http.ResponseWriter, *http.Request) error
+	BeforeAPIResponse(http.ResponseWriter, *http.Request, []byte) ([]byte, error)
+	AfterAPIResponse(http.ResponseWriter, *http.Request, []byte) ([]byte, error)
 
 	BeforeAPICreate(http.ResponseWriter, *http.Request) error
 	AfterAPICreate(http.ResponseWriter, *http.Request) error
@@ -181,13 +181,13 @@ func (i Item) String() string {
 }
 
 // BeforeAPIResponse is a no-op to ensure structs which embed Item implement Hookable
-func (i Item) BeforeAPIResponse(res http.ResponseWriter, req *http.Request) error {
-	return nil
+func (i Item) BeforeAPIResponse(res http.ResponseWriter, req *http.Request, data []byte) ([]byte, error) {
+	return data, nil
 }
 
 // AfterAPIResponse is a no-op to ensure structs which embed Item implement Hookable
-func (i Item) AfterAPIResponse(res http.ResponseWriter, req *http.Request) error {
-	return nil
+func (i Item) AfterAPIResponse(res http.ResponseWriter, req *http.Request, data []byte) ([]byte, error) {
+	return data, nil
 }
 
 // BeforeAPICreate is a no-op to ensure structs which embed Item implement Hookable


### PR DESCRIPTION
As discussed in issue #302, this provides two new hooks so that we can interact with the JSON response from the Ponzu API. Use cases mentioned so far include spellchecks, shortcode replacement and sanitization.

The function signatures are slightly different to the other hooks as the ```[]byte``` slice representing the JSON response is passed to both new hooks, and in the case of ```BeforeAPIResponse``` also returned ready to be sent by Ponzu.

```
BeforeAPIResponse(http.ResponseWriter, *http.Request, []byte) ([]byte, error)
AfterAPIResponse(http.ResponseWriter, *http.Request, []byte) error
```
After ```APIResponse``` is worth having in my mind, it may be useful for logging or notifications.

If this is OK, I will of course also amend the docs to reflect the new hooks, and make a separate pull request.

No rush on feedback, appreciate you are busy, just wanted to send now as I'm liable to get distracted and forget about it myself :)