### PR TITLE
Add support for building snaps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,26 @@
+name: ponzu
+version: '1.0'
+summary: Headless CMS with automatic JSON API
+description: |
+  Headless CMS with automatic JSON API. Featuring auto-HTTPS from 
+  Lets Encrypt, HTTP/2 Server Push, and flexible server framework 
+  written in Go.
+grade: stable
+confinement: strict
+base: core18
+parts:
+  ponzu:
+    plugin: go
+    source: https://github.com/ponzu-cms/ponzu.git
+    go-importpath: github.com/ponzu-cms/ponzu
+    build-packages:
+      - build-essential
+apps:
+  ponzu:
+    command: bin/ponzu
+    daemon: simple
+    restart-condition: on-abnormal
+    plugs:
+      - home
+      - network
+      - network-bind


### PR DESCRIPTION
Hi Steve,

Following up on what we briefly discussed, this is the PR for building a snap package of ponzu.

**Build and test**

You can use:

- local system with snapcraft command line tool (basically this PR)
- build/CI tool or system of your choice
- our online, free build service (build.snapcraft.io)

**Build locally**

I used Ubuntu 18.04 for this.

snap install snapcraft --classic --beta
git clone https://github.com/igorljubuncic/ponzu.git
cd ponzu
git checkout add-snapcraft
snapcraft

This command will generate a <ponzu-version>.snap file, something like ponzu_1.0_amd64.snap.

**Install locally**

snap install ponzu_1.0_amd64.snap --dangerous

The --dangerous flag is necessary because the app (snap) does not originate from the snap store just yet and is not digitally signed.

**Run ponzu**

snap run ponzu "options"

**Register dev account**

You can do this here: https://snapcraft.io/account.

**Register ponzu name in the store**

This can be done on the command line with snapcraft:

snapcraft login
snapcraft register

**Upload/push ponzu to the store**

snapcraft push ponzu_1.0_amd64.snap --release edge

We use release channels to denote risk, as follows:

- edge, typically for git master
- beta, beta testing
- candidate
- stable

You can promote to different channels after testing and validation.

**Install from store for (a second) test**

snap install ponzu --edge

I think this covers it.

Once you land the PR, we can help you with the promotion of ponzu.

Feel free to ask any questions you may have.

Thanks!