### PR TITLE
make slug editable

### DIFF
--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -238,8 +238,7 @@ func addPostDefaultFieldsToEditorView(p Editable, e *Editor) error {
 			View: Input("Slug", p, map[string]string{
 				"label":       "URL Slug",
 				"type":        "text",
-				"disabled":    "true",
-				"placeholder": "Will be set automatically",
+				"placeholder": "Can be left empty for new item",
 			}),
 		},
 		{

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -150,12 +150,14 @@ func Form(post Editable, fields ...Field) ([]byte, error) {
 			external = form.find('.post-controls.external'),
 			id = form.find('input[name=id]'),
 			timestamp = $('.__ponzu.content-only'),
-			slug = $('input[name=slug]');
+			slug = $('input[name=slug]'),
+			allowEmptySlug = false;
 		
 		// hide if this is a new post, or a non-post editor page
 		if (id.val() === '-1' || form.attr('action') !== '/admin/edit') {
 			del.hide();
 			external.hide();
+			allowEmptySlug = true;
 		}
 
 		// hide approval if not on a pending content item
@@ -167,10 +169,18 @@ func Form(post Editable, fields ...Field) ([]byte, error) {
 		if (form.attr('action') === '/admin/addon') {
 			timestamp.hide();
 			slug.parent().hide();
+			allowEmptySlug = true;
 		}
 
 		save.on('click', function(e) {
 			e.preventDefault();
+
+			if (!allowEmptySlug) {
+				if (slug.length > 1 && slug.eq(1).val() === "") {
+					alert("Slug cannot be empty");
+					return;
+				}
+			}
 
 			if (getParam('status') === 'pending') {
 				var action = form.attr('action');
@@ -238,7 +248,7 @@ func addPostDefaultFieldsToEditorView(p Editable, e *Editor) error {
 			View: Input("Slug", p, map[string]string{
 				"label":       "URL Slug",
 				"type":        "text",
-				"placeholder": "Can be left empty for new item",
+				"placeholder": "Can be left empty, only for new item",
 			}),
 		},
 		{

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -108,33 +108,38 @@ func update(ns, id string, data url.Values, existingContent *[]byte) (int, error
 			return err
 		}
 
-		// update the slug,type:id in contentIndex if public content
+		// get slugs data
+		var (
+			existingSlug, newSlug string
+		)
+		existingSlug = data.Get("slug")
+		if len(data["slug"]) > 1 {
+			newSlug = data["slug"][1]
+		}
+
+		// update the slug (type:id) in contentIndex if public content
 		if specifier == "" {
-			if len(data["slug"]) > 1 {
-				slug := data["slug"][0]
-				customSlug := data["slug"][1]
 
-				target := fmt.Sprintf("%s:%d", ns, cid)
-				// if slug changed
-				if slug != customSlug {
-					ci := tx.Bucket([]byte("__contentIndex"))
-					if ci == nil {
-						return bolt.ErrBucketNotFound
-					}
+			target := fmt.Sprintf("%s:%d", ns, cid)
+			// if slug changed and valid
+			if existingSlug != newSlug && newSlug != "" {
+				ci := tx.Bucket([]byte("__contentIndex"))
+				if ci == nil {
+					return bolt.ErrBucketNotFound
+				}
 
-					// remove existing slug from __contentIndex
-					err = ci.Delete([]byte(fmt.Sprintf("%s", slug)))
-					if err != nil {
-						return err
-					}
+				// remove existing slug from __contentIndex
+				err = ci.Delete([]byte(fmt.Sprintf("%s", existingSlug)))
+				if err != nil {
+					return err
+				}
 
-					// insert new slug to __contentIndex
-					k := []byte(customSlug)
-					v := []byte(target)
-					err := ci.Put(k, v)
-					if err != nil {
-						return err
-					}
+				// insert new slug to __contentIndex
+				k := []byte(newSlug)
+				v := []byte(target)
+				err := ci.Put(k, v)
+				if err != nil {
+					return err
 				}
 			}
 		}
@@ -801,20 +806,22 @@ func postToJSON(ns string, data url.Values) ([]byte, error) {
 		return nil, err
 	}
 
+	// get slugs data
+	var (
+		existingSlug, newSlug string
+	)
+	existingSlug = data.Get("slug")
+	if len(data["slug"]) > 1 {
+		newSlug = data["slug"][1]
+	}
+
+	// for new item
 	// if the content has no slug, and has no specifier, create a slug, check it
 	// for duplicates, and add it to our values
-	if data.Get("slug") == "" && data.Get("__specifier") == "" {
-		// check custom slug
-		slugsData := data["slug"]
-		if len(slugsData) > 1 && data["slug"][1] != "" {
-			customSlug := data["slug"][1]
+	if existingSlug == "" && data.Get("__specifier") == "" {
 
-			if customSlug != "" {
-				post.(item.Sluggable).SetSlug(customSlug)
-				data.Set("slug", customSlug)
-			}
-		} else {
-			// generate default slug
+		// if no new slug specified, generate slug
+		if newSlug == "" {
 			slug, err := item.Slug(post.(item.Identifiable))
 			if err != nil {
 				return nil, err
@@ -827,7 +834,17 @@ func postToJSON(ns string, data url.Values) ([]byte, error) {
 
 			post.(item.Sluggable).SetSlug(slug)
 			data.Set("slug", slug)
+		} else {
+			post.(item.Sluggable).SetSlug(newSlug)
+			data.Set("slug", newSlug)
 		}
+	}
+
+	// for editing item
+	// prevent edit to empty slug
+	if existingSlug != "" && newSlug == "" {
+		post.(item.Sluggable).SetSlug(existingSlug)
+		data.Set("slug", existingSlug)
 	}
 
 	// marshall content struct to json for db storage


### PR DESCRIPTION
Started from my question on #308 about my needs to edit slug, I make some changes myself to achieve that.
First time contributing here. Honestly I'm not that familiar about the design of this repo. I've tried to make changes as unobtrusive as possible, but let me know if the changes is not acceptable.

Actually there are several concerns when I'm working on this:
1. I'm not sure whether slug is should to be editable or not
2. Currently on the editor slug data is sent twice, from a hidden field and a disabled text field. Not sure if it's intended or not, but I'm using both value to check if slug is being edited by user
3. `value.Get("field_name")` only return the first value of the specified field, I use `value["field_name"][1]` to get the second value of a field. Not sure if it's deemed not neat

Let me know what you guys think :)