### PR TITLE
Allow data directories outside pwd

### DIFF
--- a/system/admin/upload/upload.go
+++ b/system/admin/upload/upload.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/ponzu-cms/ponzu/system/cfg"
+
 	"github.com/ponzu-cms/ponzu/system/db"
 	"github.com/ponzu-cms/ponzu/system/item"
 )
@@ -41,7 +43,6 @@ func StoreFiles(req *http.Request) (map[string]string, error) {
 	req.Form.Set("timestamp", ts)
 
 	// get or create upload directory to save files from request
-
 	i, err := strconv.ParseInt(ts, 10, 64)
 	if err != nil {
 		return nil, err
@@ -51,7 +52,6 @@ func StoreFiles(req *http.Request) (map[string]string, error) {
 
 	urlPathPrefix := "api"
 	uploadDirName := "uploads"
-
 	uploadDir := filepath.Join(cfg.UploadDir(), fmt.Sprintf("%d", tm.Year()), fmt.Sprintf("%02d", tm.Month()))
 	err = os.MkdirAll(uploadDir, os.ModeDir|os.ModePerm)
 	if err != nil {

--- a/system/admin/upload/upload.go
+++ b/system/admin/upload/upload.go
@@ -41,11 +41,6 @@ func StoreFiles(req *http.Request) (map[string]string, error) {
 	req.Form.Set("timestamp", ts)
 
 	// get or create upload directory to save files from request
-	pwd, err := os.Getwd()
-	if err != nil {
-		err := fmt.Errorf("Failed to locate current directory: %s", err)
-		return nil, err
-	}
 
 	i, err := strconv.ParseInt(ts, 10, 64)
 	if err != nil {
@@ -57,7 +52,7 @@ func StoreFiles(req *http.Request) (map[string]string, error) {
 	urlPathPrefix := "api"
 	uploadDirName := "uploads"
 
-	uploadDir := filepath.Join(pwd, uploadDirName, fmt.Sprintf("%d", tm.Year()), fmt.Sprintf("%02d", tm.Month()))
+	uploadDir := filepath.Join(cfg.UploadDir(), fmt.Sprintf("%d", tm.Year()), fmt.Sprintf("%02d", tm.Month()))
 	err = os.MkdirAll(uploadDir, os.ModeDir|os.ModePerm)
 	if err != nil {
 		return nil, err

--- a/system/api/analytics/init.go
+++ b/system/api/analytics/init.go
@@ -7,11 +7,13 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
 
 	"github.com/boltdb/bolt"
+	"github.com/ponzu-cms/ponzu/system/cfg"
 )
 
 type apiRequest struct {
@@ -72,7 +74,8 @@ func Close() {
 // sets up the queue/batching channel
 func Init() {
 	var err error
-	store, err = bolt.Open("analytics.db", 0666, nil)
+	analyticsDb := filepath.Join(cfg.DataDir(),"analytics.db")
+	store, err = bolt.Open(analyticsDb, 0666, nil)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/system/cfg/env.go
+++ b/system/cfg/env.go
@@ -1,0 +1,56 @@
+package cfg
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+)
+
+func getWd() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		log.Fatalln("Couldn't find working directory", err)
+	}
+	return wd
+}
+
+func DataDir() string {
+	dataDir := os.Getenv("PONZU_DATA_DIR")
+	if dataDir == "" {
+		return getWd()
+	}
+	return dataDir
+}
+
+func TlsDir() string {
+	tlsDir := os.Getenv("PONZU_TLS_DIR")
+	if tlsDir == "" {
+		tlsDir = filepath.Join(getWd(), "cmd", "ponzu", "vendor", "github.com", "ponzu-cms", "ponzu", "system", "tls")
+	}
+	return tlsDir
+}
+
+func AdminStaticDir() string {
+	staticDir := os.Getenv("PONZU_ADMINSTATIC_DIR")
+	if staticDir == "" {
+
+		staticDir = filepath.Join(getWd(), "cmd", "ponzu", "vendor", "github.com", "ponzu-cms", "ponzu", "system", "admin", "static")
+	}
+	return staticDir
+}
+
+func UploadDir() string {
+	uploadDir := os.Getenv("PONZU_UPLOAD_DIR")
+	if uploadDir == "" {
+		uploadDir = filepath.Join(DataDir(),"uploads")
+	}
+	return uploadDir
+}
+
+func SearchDir() string {
+	searchDir := os.Getenv("PONZU_SEARCH_DIR")
+	if searchDir == "" {
+		searchDir = filepath.Join(DataDir(),"search")
+	}
+	return searchDir
+}

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -5,6 +5,9 @@ package db
 
 import (
 	"log"
+	"path/filepath"
+
+	"github.com/ponzu-cms/ponzu/system/cfg"
 
 	"github.com/ponzu-cms/ponzu/system/item"
 	"github.com/ponzu-cms/ponzu/system/search"

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -46,7 +46,8 @@ func Init() {
 	}
 
 	var err error
-	store, err = bolt.Open("system.db", 0666, nil)
+	systemDb := filepath.Join(cfg.DataDir(),"system.db")
+	store, err = bolt.Open(systemDb, 0666, nil)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/system/search/backup.go
+++ b/system/search/backup.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/ponzu-cms/ponzu/system/cfg"
+
 	"github.com/ponzu-cms/ponzu/system/backup"
 )
 
@@ -26,7 +28,7 @@ func Backup(ctx context.Context, res http.ResponseWriter) error {
 		return err
 	}
 
-	err = backup.ArchiveFS(ctx, "search", f)
+	err = backup.ArchiveFS(ctx, cfg.SearchDir(), f)
 	if err != nil {
 		return err
 	}

--- a/system/search/search.go
+++ b/system/search/search.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ponzu-cms/ponzu/system/cfg"
+
 	"github.com/ponzu-cms/ponzu/system/item"
 
 	"github.com/blevesearch/bleve"
@@ -62,13 +64,7 @@ func MapIndex(typeName string) error {
 	idxName := typeName + ".index"
 	var idx bleve.Index
 
-	// check if index exists, use it or create new one
-	pwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
-	searchPath := filepath.Join(pwd, "search")
+	searchPath := cfg.SearchDir()
 
 	err = os.MkdirAll(searchPath, os.ModeDir|os.ModePerm)
 	if err != nil {

--- a/system/tls/devcerts.go
+++ b/system/tls/devcerts.go
@@ -26,6 +26,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/ponzu-cms/ponzu/system/cfg"
+
 	"github.com/ponzu-cms/ponzu/system/db"
 )
 
@@ -112,12 +114,8 @@ func setupDev() {
 	}
 
 	// overwrite/create directory for devcerts
-	pwd, err := os.Getwd()
-	if err != nil {
-		log.Fatalln("Couldn't find working directory to locate or save dev certificates:", err)
-	}
 
-	vendorTLSPath := filepath.Join(pwd, "cmd", "ponzu", "vendor", "github.com", "ponzu-cms", "ponzu", "system", "tls")
+	vendorTLSPath := cfg.TlsDir()
 	devcertsPath := filepath.Join(vendorTLSPath, "devcerts")
 
 	// clear all old certs if found
@@ -126,7 +124,7 @@ func setupDev() {
 		log.Fatalln("Failed to remove old files from dev certificate directory:", err)
 	}
 
-	err = os.Mkdir(devcertsPath, os.ModeDir|os.ModePerm)
+	err = os.MkdirAll(devcertsPath, os.ModeDir|os.ModePerm)
 	if err != nil {
 		log.Fatalln("Failed to create directory to locate or save dev certificates:", err)
 	}

--- a/system/tls/enable.go
+++ b/system/tls/enable.go
@@ -13,18 +13,15 @@ import (
 	"time"
 
 	"github.com/ponzu-cms/ponzu/system/db"
+	"github.com/ponzu-cms/ponzu/system/cfg"
 	"golang.org/x/crypto/acme/autocert"
 )
 
 // newManager attempts to locate or create the cert cache directory and the
 // certs for TLS encryption and returns an autocert.Manager
 func newManager() autocert.Manager {
-	pwd, err := os.Getwd()
-	if err != nil {
-		log.Fatalln("Couldn't find working directory to locate or save certificates.")
-	}
 
-	cache := autocert.DirCache(filepath.Join(pwd, "system", "tls", "certs"))
+	cache := autocert.DirCache(filepath.Join(cfg.TlsDir(), "certs"))
 	if _, err := os.Stat(string(cache)); os.IsNotExist(err) {
 		err := os.MkdirAll(string(cache), os.ModePerm|os.ModeDir)
 		if err != nil {

--- a/system/tls/enabledev.go
+++ b/system/tls/enabledev.go
@@ -3,8 +3,9 @@ package tls
 import (
 	"log"
 	"net/http"
-	"os"
 	"path/filepath"
+
+	"github.com/ponzu-cms/ponzu/system/cfg"
 )
 
 // EnableDev generates self-signed SSL certificates to use HTTPS & HTTP/2 while
@@ -15,13 +16,7 @@ import (
 func EnableDev() {
 	setupDev()
 
-	pwd, err := os.Getwd()
-	if err != nil {
-		log.Fatalln("Couldn't find working directory to activate dev certificates:", err)
-	}
-
-	vendorPath := filepath.Join(pwd, "cmd", "ponzu", "vendor", "github.com", "ponzu-cms", "ponzu", "system", "tls")
-
+	vendorPath := cfg.TlsDir()
 	cert := filepath.Join(vendorPath, "devcerts", "cert.pem")
 	key := filepath.Join(vendorPath, "devcerts", "key.pem")
 


### PR DESCRIPTION
Running ponzu-cms inside a docker container, and maintaining
data files in a volume (or several) was not possible with the
previous directory schema without copying files or binaries
to the volume.

This commit adds several environment variables to allow the
administrator to specify paths for directories while
retaining backwards compatibility.

- PONZU_DATA_DIR : is the directory where all the data and other
                   directories will be stored, still the other
                   directories can be controlled by the other env
                   variables.

- PONZU_TLS_DIR : is the directory to store devcerts and autocerts

- PONZU_ADMINSTATIC_DIR : directory where the admin static files are
                          served from.

- PONZU_UPLOAD_DIR: upload files directory

- PONZU_SEARCH_DIR: index directory for searches